### PR TITLE
[FEAT] API 공통 응답 및 Exception 처리 구현

### DIFF
--- a/src/main/java/org/lostnomore/backend/global/advice/GlobalExceptionHandler.java
+++ b/src/main/java/org/lostnomore/backend/global/advice/GlobalExceptionHandler.java
@@ -1,0 +1,48 @@
+package org.lostnomore.backend.global.advice;
+
+import lombok.extern.slf4j.Slf4j;
+import org.lostnomore.backend.global.exception.BusinessException;
+import org.lostnomore.backend.global.exception.code.BusinessErrorCode;
+import org.lostnomore.backend.global.dto.ResponseDto;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.MissingRequestHeaderException;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+import java.util.Objects;
+
+@Slf4j
+@RestControllerAdvice
+public class GlobalExceptionHandler {
+
+    @ExceptionHandler(value = {BusinessException.class})
+    public ResponseEntity<ResponseDto<BusinessErrorCode>> handleBusinessException(BusinessException e) {
+        return ResponseEntity
+                .status(e.getErrorCode().getHttpStatus())
+                .body(ResponseDto.fail(e.getErrorCode()));
+    }
+
+    @ExceptionHandler(value = {MethodArgumentNotValidException.class})
+    public ResponseEntity<ResponseDto<BusinessErrorCode>> handleMethodArgumentNotValidException(MethodArgumentNotValidException e) {
+        return ResponseEntity
+                .status(HttpStatus.BAD_REQUEST)
+                .body(ResponseDto.validFail(Objects.requireNonNull(e.getBindingResult().getFieldError()).getDefaultMessage()));
+    }
+
+    @ExceptionHandler(value = {MissingRequestHeaderException.class})
+    public ResponseEntity<ResponseDto<BusinessErrorCode>> handleMissingHeaderException(MissingRequestHeaderException e) {
+        return ResponseEntity
+                .status(BusinessErrorCode.MISSING_REQUIRED_HEADER.getHttpStatus())
+                .body(ResponseDto.fail(BusinessErrorCode.MISSING_REQUIRED_HEADER));
+    }
+
+    @ExceptionHandler(value = {Exception.class})
+    public ResponseEntity<ResponseDto<BusinessErrorCode>> handleException(java.lang.Exception e) {
+        log.error("Unhandled exception occurred: {}", e.getMessage(), e);
+        return ResponseEntity
+                .status(BusinessErrorCode.INTERNAL_SERVER_ERROR.getHttpStatus())
+                .body(ResponseDto.fail(BusinessErrorCode.INTERNAL_SERVER_ERROR));
+    }
+}

--- a/src/main/java/org/lostnomore/backend/global/dto/ErrorDto.java
+++ b/src/main/java/org/lostnomore/backend/global/dto/ErrorDto.java
@@ -1,0 +1,10 @@
+package org.lostnomore.backend.global.dto;
+
+public record ErrorDto(
+        int code,
+        String message
+) {
+    public static ErrorDto of(int code, String message) {
+        return new ErrorDto(code, message);
+    }
+}

--- a/src/main/java/org/lostnomore/backend/global/dto/ResponseDto.java
+++ b/src/main/java/org/lostnomore/backend/global/dto/ResponseDto.java
@@ -1,0 +1,29 @@
+package org.lostnomore.backend.global.dto;
+
+import org.lostnomore.backend.global.exception.code.DefaultErrorCode;
+import org.springframework.http.HttpStatus;
+
+public record ResponseDto<T> (
+        boolean isSuccess,
+        T data,
+        ErrorDto errorDto
+) {
+    // 결과가 없는 성공 응답
+    public static <T> ResponseDto<T> success() {
+        return new ResponseDto<>(true, null, null);
+    }
+
+    // 성공 응답
+    public static <T> ResponseDto<T> success(T data) {
+        return new ResponseDto<>(true, data, null);
+    }
+
+    // 실패 응답
+    public static <T> ResponseDto<T> fail(DefaultErrorCode errorCode) {
+        return new ResponseDto<>(false, null, ErrorDto.of(errorCode.getHttpStatus().value(), errorCode.getMessage()));
+    }
+
+    public static <T> ResponseDto<T> validFail(String errorMessage) {
+        return new ResponseDto<>(false, null, ErrorDto.of(HttpStatus.BAD_REQUEST.value(), errorMessage));
+    }
+}

--- a/src/main/java/org/lostnomore/backend/global/exception/BusinessException.java
+++ b/src/main/java/org/lostnomore/backend/global/exception/BusinessException.java
@@ -1,0 +1,11 @@
+package org.lostnomore.backend.global.exception;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.lostnomore.backend.global.exception.code.DefaultErrorCode;
+
+@Getter
+@AllArgsConstructor
+public class BusinessException extends RuntimeException {
+    private final DefaultErrorCode errorCode;
+}

--- a/src/main/java/org/lostnomore/backend/global/exception/code/BusinessErrorCode.java
+++ b/src/main/java/org/lostnomore/backend/global/exception/code/BusinessErrorCode.java
@@ -1,0 +1,19 @@
+package org.lostnomore.backend.global.exception.code;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@AllArgsConstructor
+public enum BusinessErrorCode implements DefaultErrorCode {
+    //400 BAD_REQUEST
+    BAD_REQUEST(HttpStatus.BAD_REQUEST, "잘못된 요청입니다."),
+    MISSING_REQUIRED_HEADER(HttpStatus.BAD_REQUEST,"필수 헤더가 누락되었습니다."),
+    // 500 INTERNAL_SEVER_ERROR
+    INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "서버 내부 오류입니다."),
+    ;
+
+    private HttpStatus httpStatus;
+    private String message;
+}

--- a/src/main/java/org/lostnomore/backend/global/exception/code/DefaultErrorCode.java
+++ b/src/main/java/org/lostnomore/backend/global/exception/code/DefaultErrorCode.java
@@ -1,0 +1,8 @@
+package org.lostnomore.backend.global.exception.code;
+
+import org.springframework.http.HttpStatus;
+
+public interface DefaultErrorCode {
+    HttpStatus getHttpStatus();
+    String getMessage();
+}

--- a/src/main/java/org/lostnomore/backend/global/exception/code/ItemErrorCode.java
+++ b/src/main/java/org/lostnomore/backend/global/exception/code/ItemErrorCode.java
@@ -1,0 +1,16 @@
+package org.lostnomore.backend.global.exception.code;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@AllArgsConstructor
+public enum ItemErrorCode implements DefaultErrorCode {
+    //404 BAD_REQUEST
+    ITEM_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 아이템을 찾을 수 없습니다."),
+    ;
+
+    private HttpStatus httpStatus;
+    private String message;
+}


### PR DESCRIPTION
## Related issue 🛠
[//]: # (해당하는 이슈 번호 달아주기)
- closed #3 

## Work Description ✏️
[//]: # (작업 내용 간단 소개)
-  api 공통 응답을 구현했습니다. 
- record에서 필드명과 같은 이름으로 매개변수 없는 생성자를 만들지 못해서 `success` 필드를 `isSuccess`로 수정했습니다.
- Exception 처리를 구현했습니다.
- ErrorCode는 도메인 별로 세분화하고(ItemErrorCode, NotificationErrorCode....), Exception은 BusinessException 하나로 통일했습니다. 

## Uncompleted Tasks 😅
[//]: # (없다면 N/A)
- [ ] N/A

## To Reviewers 📢
[//]: # (reviewer가 알면 좋은 내용들)
확인하시고 의견주세용