### PR TITLE
[FEAT] 메인페이지 분실물 관련 조회 API 구현 

### DIFF
--- a/src/main/java/org/lostnomore/backend/global/domain/BaseEntity.java
+++ b/src/main/java/org/lostnomore/backend/global/domain/BaseEntity.java
@@ -5,10 +5,13 @@ import jakarta.persistence.Column;
 import jakarta.persistence.EntityListeners;
 import jakarta.persistence.MappedSuperclass;
 import java.time.LocalDateTime;
+
+import lombok.Getter;
 import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.annotation.LastModifiedDate;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
+@Getter
 @MappedSuperclass
 @EntityListeners(AuditingEntityListener.class)
 public class BaseEntity {

--- a/src/main/java/org/lostnomore/backend/item/controller/LostItemController.java
+++ b/src/main/java/org/lostnomore/backend/item/controller/LostItemController.java
@@ -3,6 +3,7 @@ package org.lostnomore.backend.item.controller;
 import lombok.RequiredArgsConstructor;
 import org.lostnomore.backend.global.dto.ResponseDto;
 import org.lostnomore.backend.item.dto.response.ItemsCountDto;
+import org.lostnomore.backend.item.dto.response.RecentItemsDto;
 import org.lostnomore.backend.item.service.LostItemService;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -18,6 +19,13 @@ public class LostItemController {
     @GetMapping("items/count")
     public ResponseEntity<ResponseDto<ItemsCountDto>> getItemsCount () {
         return ResponseEntity.status(HttpStatus.OK).body(ResponseDto.success(lostItemService.getItemsCount()));
+    }
+
+    @GetMapping("items/recent")
+    public ResponseEntity<ResponseDto<RecentItemsDto>> getRecentItems (
+            final Long userId
+    ) {
+        return ResponseEntity.status(HttpStatus.OK).body(ResponseDto.success(lostItemService.getRecentItems(userId)));
     }
 
 }

--- a/src/main/java/org/lostnomore/backend/item/controller/LostItemController.java
+++ b/src/main/java/org/lostnomore/backend/item/controller/LostItemController.java
@@ -1,7 +1,23 @@
 package org.lostnomore.backend.item.controller;
 
+import lombok.RequiredArgsConstructor;
+import org.lostnomore.backend.global.dto.ResponseDto;
+import org.lostnomore.backend.item.dto.response.ItemsCountDto;
+import org.lostnomore.backend.item.service.LostItemService;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
+@RequiredArgsConstructor
 public class LostItemController {
+
+    private final LostItemService lostItemService;
+
+    @GetMapping("items/count")
+    public ResponseEntity<ResponseDto<ItemsCountDto>> getItemsCount () {
+        return ResponseEntity.status(HttpStatus.OK).body(ResponseDto.success(lostItemService.getItemsCount()));
+    }
+
 }

--- a/src/main/java/org/lostnomore/backend/item/domain/LostItem.java
+++ b/src/main/java/org/lostnomore/backend/item/domain/LostItem.java
@@ -14,12 +14,13 @@ import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.lostnomore.backend.global.domain.BaseEntity;
 
 @Getter
 @Table(name = "lost_item")
 @Entity
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class LostItem {
+public class LostItem extends BaseEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/java/org/lostnomore/backend/item/dto/response/ItemsCountDto.java
+++ b/src/main/java/org/lostnomore/backend/item/dto/response/ItemsCountDto.java
@@ -1,0 +1,13 @@
+package org.lostnomore.backend.item.dto.response;
+
+public record ItemsCountDto(
+        int today,
+        int total
+) {
+    public static ItemsCountDto of(int todayCount, int totalCount) {
+        return new ItemsCountDto(
+                todayCount,
+                totalCount
+        );
+    }
+}

--- a/src/main/java/org/lostnomore/backend/item/dto/response/RecentItemsDto.java
+++ b/src/main/java/org/lostnomore/backend/item/dto/response/RecentItemsDto.java
@@ -1,0 +1,36 @@
+package org.lostnomore.backend.item.dto.response;
+
+import org.lostnomore.backend.item.domain.LostItem;
+
+import java.time.LocalDate;
+import java.util.List;
+
+public record RecentItemsDto(
+        List<RecentItemDto> recentItems
+) {
+    public static RecentItemsDto from(List<LostItem> items) {
+        return new RecentItemsDto(
+                items.stream()
+                        .map(RecentItemDto::from)
+                        .toList()
+        );
+    }
+
+    public record RecentItemDto(
+            Long id,
+            String name,
+            LocalDate date,
+            String location,
+            String imageUrl
+    ) {
+        public static RecentItemDto from(LostItem item) {
+            return new RecentItemDto(
+                    item.getId(),
+                    item.getName(),
+                    item.getDate(),
+                    item.getLocation().getName(),
+                    item.getImage()
+            );
+        }
+    }
+}

--- a/src/main/java/org/lostnomore/backend/item/manager/LostItemRetriever.java
+++ b/src/main/java/org/lostnomore/backend/item/manager/LostItemRetriever.java
@@ -1,0 +1,19 @@
+package org.lostnomore.backend.item.manager;
+
+import jakarta.persistence.Tuple;
+import lombok.RequiredArgsConstructor;
+import org.lostnomore.backend.item.repository.LostItemRepository;
+import org.springframework.stereotype.Component;
+
+import java.time.LocalDateTime;
+
+@Component
+@RequiredArgsConstructor
+public class LostItemRetriever {
+
+    private final LostItemRepository lostItemRepository;
+
+    public Tuple findItemCountByCreatedAtAfter(final LocalDateTime today) {
+        return lostItemRepository.findItemCountByCreatedAtAfter(today);
+    }
+}

--- a/src/main/java/org/lostnomore/backend/item/manager/LostItemRetriever.java
+++ b/src/main/java/org/lostnomore/backend/item/manager/LostItemRetriever.java
@@ -2,7 +2,10 @@ package org.lostnomore.backend.item.manager;
 
 import jakarta.persistence.Tuple;
 import lombok.RequiredArgsConstructor;
+import org.lostnomore.backend.item.domain.LostItem;
 import org.lostnomore.backend.item.repository.LostItemRepository;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Component;
 
 import java.time.LocalDateTime;
@@ -15,5 +18,12 @@ public class LostItemRetriever {
 
     public Tuple findItemCountByCreatedAtAfter(final LocalDateTime today) {
         return lostItemRepository.findItemCountByCreatedAtAfter(today);
+    }
+
+    public Page<LostItem> findRecentItemsByUserId(
+            final Long userId,
+            final Pageable pageable
+    ) {
+        return lostItemRepository.findRecentItemsByUserId(userId, pageable);
     }
 }

--- a/src/main/java/org/lostnomore/backend/item/repository/LostItemRepository.java
+++ b/src/main/java/org/lostnomore/backend/item/repository/LostItemRepository.java
@@ -1,9 +1,21 @@
 package org.lostnomore.backend.item.repository;
 
+import jakarta.persistence.Tuple;
 import org.lostnomore.backend.item.domain.LostItem;
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.stereotype.Repository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.time.LocalDateTime;
 
 public interface LostItemRepository extends JpaRepository<LostItem, Long> {
+
+    @Query("""
+            SELECT 
+                COUNT (case when l.createdDate >= :today THEN 1 END) as todayCount,
+                COUNT(l) as totalCount
+            FROM LostItem l
+            """)
+    Tuple findItemCountByCreatedAtAfter(@Param("today") LocalDateTime today);
 
 }

--- a/src/main/java/org/lostnomore/backend/item/repository/LostItemRepository.java
+++ b/src/main/java/org/lostnomore/backend/item/repository/LostItemRepository.java
@@ -2,6 +2,8 @@ package org.lostnomore.backend.item.repository;
 
 import jakarta.persistence.Tuple;
 import org.lostnomore.backend.item.domain.LostItem;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
@@ -17,5 +19,15 @@ public interface LostItemRepository extends JpaRepository<LostItem, Long> {
             FROM LostItem l
             """)
     Tuple findItemCountByCreatedAtAfter(@Param("today") LocalDateTime today);
+
+    @Query("""
+       SELECT l FROM LostItem l
+       JOIN FETCH l.location
+       WHERE l.category IN (
+           SELECT s.category FROM Subscribe s WHERE s.user.id = :userId
+       )
+       ORDER BY l.createdDate DESC
+       """)
+    Page<LostItem> findRecentItemsByUserId(Long userId, Pageable pageable);
 
 }

--- a/src/main/java/org/lostnomore/backend/item/service/LostItemService.java
+++ b/src/main/java/org/lostnomore/backend/item/service/LostItemService.java
@@ -1,7 +1,27 @@
 package org.lostnomore.backend.item.service;
 
+import jakarta.persistence.Tuple;
+import lombok.RequiredArgsConstructor;
+import org.lostnomore.backend.item.dto.response.ItemsCountDto;
+import org.lostnomore.backend.item.manager.LostItemRetriever;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDate;
 
 @Service
+@RequiredArgsConstructor
 public class LostItemService {
+
+    private final LostItemRetriever lostItemRetriever;
+
+    @Transactional(readOnly = true)
+    public ItemsCountDto getItemsCount() {
+        Tuple stats = lostItemRetriever.findItemCountByCreatedAtAfter(LocalDate.now().atStartOfDay());
+
+        Long todayCount = stats.get(0, Long.class);
+        Long totalCount = stats.get(1, Long.class);
+
+        return ItemsCountDto.of(todayCount.intValue(), totalCount.intValue());
+    }
 }

--- a/src/main/java/org/lostnomore/backend/item/service/LostItemService.java
+++ b/src/main/java/org/lostnomore/backend/item/service/LostItemService.java
@@ -2,12 +2,17 @@ package org.lostnomore.backend.item.service;
 
 import jakarta.persistence.Tuple;
 import lombok.RequiredArgsConstructor;
+import org.lostnomore.backend.item.domain.LostItem;
 import org.lostnomore.backend.item.dto.response.ItemsCountDto;
+import org.lostnomore.backend.item.dto.response.RecentItemsDto;
 import org.lostnomore.backend.item.manager.LostItemRetriever;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDate;
+import java.util.List;
 
 @Service
 @RequiredArgsConstructor
@@ -23,5 +28,13 @@ public class LostItemService {
         Long totalCount = stats.get(1, Long.class);
 
         return ItemsCountDto.of(todayCount.intValue(), totalCount.intValue());
+    }
+
+    @Transactional(readOnly = true)
+    public RecentItemsDto getRecentItems(final Long userId) {
+        Pageable pageable = PageRequest.of(0, 9);
+        List<LostItem> recentItems = lostItemRetriever.findRecentItemsByUserId(userId, pageable).getContent();
+
+        return RecentItemsDto.from(recentItems);
     }
 }

--- a/src/test/java/org/lostnomore/backend/item/repository/LostItemRepositoryTest.java
+++ b/src/test/java/org/lostnomore/backend/item/repository/LostItemRepositoryTest.java
@@ -1,0 +1,73 @@
+
+package org.lostnomore.backend.item.repository;
+
+import jakarta.persistence.Tuple;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.lostnomore.backend.common.RepositoryTest;
+import org.lostnomore.backend.item.domain.LostItem;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@DataJpaTest
+@ExtendWith(SpringExtension.class)
+class LostItemRepositoryTest extends RepositoryTest {
+
+    @Autowired
+    private LostItemRepository lostItemRepository;
+
+    @Test
+    @DisplayName("오늘 등록된 분실물 개수와 총 개수를 올바르게 조회한다.")
+    void findItemCountByCreatedAt() {
+        // Given
+        LocalDateTime todayStart = LocalDateTime.now().toLocalDate().atStartOfDay();
+
+        LostItem item1 = LostItem.builder()
+                .name("지갑")
+                .date(LocalDate.now().minusDays(1))
+                .build();
+        lostItemRepository.save(item1);
+
+        LostItem item2 = LostItem.builder()
+                .name("가방")
+                .date(LocalDate.now())
+                .build();
+        lostItemRepository.save(item2);
+
+        LostItem item3 = LostItem.builder()
+                .name("핸드폰")
+                .date(LocalDate.now())
+                .build();
+        lostItemRepository.save(item3);
+
+        // When
+        Tuple result = lostItemRepository.findItemCountByCreatedAtAfter(todayStart);
+
+        // Then
+        assertThat(result.get(0, Long.class)).isEqualTo(3);
+        assertThat(result.get(1, Long.class)).isEqualTo(3);
+    }
+
+
+    @Test
+    @DisplayName("등록된 분실물이 없으면 0을 반환한다.")
+    void findItemCountByCreatedAt_Empty() {
+        // Given
+        LocalDateTime todayStart = LocalDateTime.now().toLocalDate().atStartOfDay();
+
+        // When
+        Tuple result = lostItemRepository.findItemCountByCreatedAtAfter(todayStart);
+
+        // Then
+        assertThat(result.get(0, Long.class)).isEqualTo(0);
+        assertThat(result.get(1, Long.class)).isEqualTo(0);
+    }
+
+}

--- a/src/test/java/org/lostnomore/backend/item/service/LostItemServiceTest.java
+++ b/src/test/java/org/lostnomore/backend/item/service/LostItemServiceTest.java
@@ -1,0 +1,71 @@
+package org.lostnomore.backend.item.service;
+
+import jakarta.persistence.Tuple;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.lostnomore.backend.item.dto.response.ItemsCountDto;
+import org.lostnomore.backend.item.manager.LostItemRetriever;
+import org.lostnomore.backend.item.repository.LostItemRepository;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class LostItemServiceTest {
+
+    @Mock
+    private LostItemRepository lostItemRepository;
+
+    @Mock
+    private LostItemRetriever lostItemRetriever;
+
+    @InjectMocks
+    private LostItemService lostItemService;
+
+    private Tuple mockTuple;
+
+    @Test
+    @DisplayName("오늘 등록된 분실물 개수와 총 개수를 정확히 반환해야 한다.")
+    void getItemsCount() {
+        // Given
+        LocalDateTime todayStart = LocalDate.now().atStartOfDay();
+        mockTuple = mock(Tuple.class);
+        when(mockTuple.get(0, Long.class)).thenReturn(5L);
+        when(mockTuple.get(1, Long.class)).thenReturn(10L);
+        when(lostItemRetriever.findItemCountByCreatedAtAfter(todayStart)).thenReturn(mockTuple);
+
+        // When
+        ItemsCountDto result = lostItemService.getItemsCount();
+
+        // Then
+        assertThat(result.today()).isEqualTo(5);
+        assertThat(result.total()).isEqualTo(10);
+    }
+
+    @Test
+    @DisplayName("등록된 분실물이 없으면 0을 반환해야 한다.")
+    void getItemsCount_Empty() {
+        // Given
+        LocalDateTime todayStart = LocalDate.now().atStartOfDay();
+        Tuple mockTuple = mock(Tuple.class);
+        when(mockTuple.get(0, Long.class)).thenReturn(0L);
+        when(mockTuple.get(1, Long.class)).thenReturn(0L);
+        when(lostItemRetriever.findItemCountByCreatedAtAfter(todayStart)).thenReturn(mockTuple);
+
+        // When
+        ItemsCountDto result = lostItemService.getItemsCount();
+
+        // Then
+        assertThat(result.today()).isEqualTo(0);
+        assertThat(result.total()).isEqualTo(0);
+    }
+
+}


### PR DESCRIPTION
## Related issue 🛠
[//]: # (해당하는 이슈 번호 달아주기)
- closed #10 

## Work Description ✏️
[//]: # (작업 내용 간단 소개)
- 전체 분실물 관련 조회 로직
- 최근 분실물 조회 로직 구현했습니다.

## Uncompleted Tasks 😅
[//]: # (없다면 N/A)
- [ ] N/A

## To Reviewers 📢
[//]: # (reviewer가 알면 좋은 내용들)
- 최근 분실물 조회 로직은 이후 엘라스틱서치 구현 후에 키워드로 수정하겠습니다. 
- 이에 테스트 코드도 전체 분실물 관련 조회만 작성하였습니다.