### PR TITLE
[FEAT] 검색 기능 구현

### DIFF
--- a/.github/workflows/dev-ci.yml
+++ b/.github/workflows/dev-ci.yml
@@ -17,7 +17,7 @@ jobs:
           - 9200:9200
         env:
           discovery.type: single-node
-          ES_JAVA_OPTS: "-Xms256m -Xmx512m"
+          ES_JAVA_OPTS: "-Xms512m -Xmx768m"
           xpack.security.enabled: "false"
 
     steps:
@@ -51,9 +51,16 @@ jobs:
       - name: Wait for Elasticsearch
         run: |
           echo "Waiting for Elasticsearch to be available..."
-          timeout 90s bash -c 'until curl -s http://elasticsearch:9200 > /dev/null; do sleep 5; echo "Still waiting..."; done'
+          timeout 180s bash -c 'until curl -s http://elasticsearch:9200 > /dev/null; do sleep 5; echo "Still waiting..."; done'
           echo "Elasticsearch is up!"
         shell: bash
+
+      - name: Check Elasticsearch Health
+        run: |
+          echo "Checking Elasticsearch cluster health..."
+          curl -X GET "http://elasticsearch:9200/_cluster/health?pretty"
+        shell: bash
+        if: always()
 
       - name: Debug Elasticsearch Logs (if failed)
         if: failure()

--- a/.github/workflows/dev-ci.yml
+++ b/.github/workflows/dev-ci.yml
@@ -45,7 +45,7 @@ jobs:
         shell: bash
 
       - name: Set Environment for CI
-        run: echo "ELASTICSEARCH_URI=http://elasticsearch:9200" >> $GITHUB_ENV
+        run: echo "ELASTICSEARCH_URI=http://localhost:9200" >> $GITHUB_ENV
         shell: bash
 
       - name: Debug Networking
@@ -56,27 +56,35 @@ jobs:
           echo "===== docker ps ====="
           docker ps
 
-          echo "===== ping elasticsearch (테스트) ====="
-          ping -c 4 elasticsearch || echo "ping 실패"
+          echo "===== netstat (열린 포트 확인) ====="
+          netstat -tulnp
+
+          echo "===== ping localhost (테스트) ====="
+          ping -c 4 localhost || echo "ping 실패"
         shell: bash
 
       - name: Wait for Elasticsearch
         run: |
           echo "Waiting for Elasticsearch to be available..."
-          timeout 180s bash -c 'until curl -s http://elasticsearch:9200 > /dev/null; do sleep 5; echo "Still waiting..."; done'
+          timeout 300s bash -c 'until curl -s http://localhost:9200 > /dev/null; do sleep 5; echo "Still waiting..."; done'
           echo "Elasticsearch is up!"
         shell: bash
 
       - name: Check Elasticsearch Health
         run: |
           echo "Checking Elasticsearch cluster health..."
-          curl -X GET "http://elasticsearch:9200/_cluster/health?pretty"
+          curl -v http://localhost:9200/_cluster/health?pretty || echo "Elasticsearch health check failed"
         shell: bash
         if: always()
 
       - name: Debug Elasticsearch Logs (if failed)
         if: failure()
-        run: docker logs $(docker ps -q --filter "ancestor=docker.elastic.co/elasticsearch/elasticsearch:8.17.1")
+        run: |
+          echo "===== Elasticsearch 컨테이너 로그 ====="
+          docker logs $(docker ps -q --filter "ancestor=docker.elastic.co/elasticsearch/elasticsearch:8.17.1")
+
+          echo "===== Elasticsearch 기동 상태 확인 (추가) ====="
+          docker inspect $(docker ps -q --filter "ancestor=docker.elastic.co/elasticsearch/elasticsearch:8.17.1")
         shell: bash
 
       - name: Build

--- a/.github/workflows/dev-ci.yml
+++ b/.github/workflows/dev-ci.yml
@@ -17,7 +17,8 @@ jobs:
           - 9200:9200
         env:
           discovery.type: single-node
-          ES_JAVA_OPTS: "-Xms512m -Xmx512m"
+          ES_JAVA_OPTS: "-Xms256m -Xmx512m"
+          xpack.security.enabled: "false"
 
     steps:
       - name: Checkout
@@ -49,9 +50,14 @@ jobs:
 
       - name: Wait for Elasticsearch
         run: |
-          curl -o wait-for-it.sh https://raw.githubusercontent.com/vishnubob/wait-for-it/master/wait-for-it.sh
-          chmod +x wait-for-it.sh
-          ./wait-for-it.sh elasticsearch:9200 --timeout=90 --strict -- echo "Elasticsearch is up"
+          echo "Waiting for Elasticsearch to be available..."
+          timeout 90s bash -c 'until curl -s http://elasticsearch:9200 > /dev/null; do sleep 5; echo "Still waiting..."; done'
+          echo "Elasticsearch is up!"
+        shell: bash
+
+      - name: Debug Elasticsearch Logs (if failed)
+        if: failure()
+        run: docker logs $(docker ps -q --filter "ancestor=docker.elastic.co/elasticsearch/elasticsearch:8.17.1")
         shell: bash
 
       - name: Build

--- a/.github/workflows/dev-ci.yml
+++ b/.github/workflows/dev-ci.yml
@@ -43,11 +43,15 @@ jobs:
           echo "${{ secrets.APPLICATION_DEV }}" | base64 --decode > ./src/main/resources/application-dev.yml
         shell: bash
 
+      - name: Set Environment for CI
+        run: echo "ELASTICSEARCH_URI=http://elasticsearch:9200" >> $GITHUB_ENV
+        shell: bash
+
       - name: Wait for Elasticsearch
         run: |
           curl -o wait-for-it.sh https://raw.githubusercontent.com/vishnubob/wait-for-it/master/wait-for-it.sh
           chmod +x wait-for-it.sh
-          ./wait-for-it.sh localhost:9200 --timeout=30 --strict -- echo "Elasticsearch is up"
+          ./wait-for-it.sh elasticsearch:9200 --timeout=90 --strict -- echo "Elasticsearch is up"
         shell: bash
 
       - name: Build

--- a/.github/workflows/dev-ci.yml
+++ b/.github/workflows/dev-ci.yml
@@ -17,7 +17,7 @@ jobs:
           - 9200:9200
         env:
           discovery.type: single-node
-          ES_JAVA_OPTS: "-Xms512m -Xmx768m"
+          ES_JAVA_OPTS: "-Xms1g -Xmx1g"
           xpack.security.enabled: "false"
 
     steps:
@@ -46,6 +46,18 @@ jobs:
 
       - name: Set Environment for CI
         run: echo "ELASTICSEARCH_URI=http://elasticsearch:9200" >> $GITHUB_ENV
+        shell: bash
+
+      - name: Debug Networking
+        run: |
+          echo "===== /etc/hosts ====="
+          cat /etc/hosts
+
+          echo "===== docker ps ====="
+          docker ps
+
+          echo "===== ping elasticsearch (테스트) ====="
+          ping -c 4 elasticsearch || echo "ping 실패"
         shell: bash
 
       - name: Wait for Elasticsearch

--- a/.github/workflows/dev-ci.yml
+++ b/.github/workflows/dev-ci.yml
@@ -10,6 +10,15 @@ jobs:
   build:
     runs-on: ubuntu-22.04
 
+    services:
+      elasticsearch:
+        image: docker.elastic.co/elasticsearch/elasticsearch:8.17.1
+        ports:
+          - 9200:9200
+        env:
+          discovery.type: single-node
+          ES_JAVA_OPTS: "-Xms512m -Xmx512m"
+
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -32,6 +41,13 @@ jobs:
         run: |
           mkdir -p ./src/main/resources
           echo "${{ secrets.APPLICATION_DEV }}" | base64 --decode > ./src/main/resources/application-dev.yml
+        shell: bash
+
+      - name: Wait for Elasticsearch
+        run: |
+          curl -o wait-for-it.sh https://raw.githubusercontent.com/vishnubob/wait-for-it/master/wait-for-it.sh
+          chmod +x wait-for-it.sh
+          ./wait-for-it.sh localhost:9200 --timeout=30 --strict -- echo "Elasticsearch is up"
         shell: bash
 
       - name: Build

--- a/.github/workflows/dev-ci.yml
+++ b/.github/workflows/dev-ci.yml
@@ -48,43 +48,15 @@ jobs:
         run: echo "ELASTICSEARCH_URI=http://localhost:9200" >> $GITHUB_ENV
         shell: bash
 
-      - name: Debug Networking
-        run: |
-          echo "===== /etc/hosts ====="
-          cat /etc/hosts
-
-          echo "===== docker ps ====="
-          docker ps
-
-          echo "===== netstat (열린 포트 확인) ====="
-          netstat -tulnp
-
-          echo "===== ping localhost (테스트) ====="
-          ping -c 4 localhost || echo "ping 실패"
-        shell: bash
-
       - name: Wait for Elasticsearch
         run: |
           echo "Waiting for Elasticsearch to be available..."
-          timeout 300s bash -c 'until curl -s http://localhost:9200 > /dev/null; do sleep 5; echo "Still waiting..."; done'
+          timeout 60s bash -c 'until curl -s http://localhost:9200 > /dev/null; do sleep 2; echo "Still waiting..."; done'
           echo "Elasticsearch is up!"
         shell: bash
 
       - name: Check Elasticsearch Health
-        run: |
-          echo "Checking Elasticsearch cluster health..."
-          curl -v http://localhost:9200/_cluster/health?pretty || echo "Elasticsearch health check failed"
-        shell: bash
-        if: always()
-
-      - name: Debug Elasticsearch Logs (if failed)
-        if: failure()
-        run: |
-          echo "===== Elasticsearch 컨테이너 로그 ====="
-          docker logs $(docker ps -q --filter "ancestor=docker.elastic.co/elasticsearch/elasticsearch:8.17.1")
-
-          echo "===== Elasticsearch 기동 상태 확인 (추가) ====="
-          docker inspect $(docker ps -q --filter "ancestor=docker.elastic.co/elasticsearch/elasticsearch:8.17.1")
+        run: curl -s http://localhost:9200/_cluster/health?pretty
         shell: bash
 
       - name: Build

--- a/build.gradle
+++ b/build.gradle
@@ -41,6 +41,7 @@ dependencies {
 	// Test
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+	testImplementation 'org.mockito:mockito-core:5.8.0'
 
 	// CI/CD health check
 	implementation 'org.springframework.boot:spring-boot-starter-actuator'

--- a/build.gradle
+++ b/build.gradle
@@ -36,7 +36,6 @@ dependencies {
 	runtimeOnly 'com.mysql:mysql-connector-j'
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 	implementation 'org.springframework.boot:spring-boot-starter-data-redis'
-	implementation 'org.springframework.boot:spring-boot-starter-data-elasticsearch'
 	runtimeOnly 'com.h2database:h2'
 
 	// Test
@@ -48,6 +47,10 @@ dependencies {
 
 	// Validation
 	implementation 'org.springframework.boot:spring-boot-starter-validation'
+
+	//elastic
+	implementation 'org.springframework.boot:spring-boot-starter-data-elasticsearch'
+	implementation 'co.elastic.clients:elasticsearch-java:8.10.2'
 }
 
 tasks.named('test') {

--- a/src/main/java/org/lostnomore/backend/item/controller/LostItemController.java
+++ b/src/main/java/org/lostnomore/backend/item/controller/LostItemController.java
@@ -2,7 +2,9 @@ package org.lostnomore.backend.item.controller;
 
 import lombok.RequiredArgsConstructor;
 import org.lostnomore.backend.global.dto.ResponseDto;
+import org.lostnomore.backend.item.dto.request.LostItemIdsDto;
 import org.lostnomore.backend.item.dto.response.ItemsCountDto;
+import org.lostnomore.backend.item.dto.response.LostItemsListDto;
 import org.lostnomore.backend.item.dto.response.RecentItemsDto;
 import org.lostnomore.backend.item.dto.request.LostItemCreateDto;
 import org.lostnomore.backend.item.dto.response.LostItemsSearchDto;
@@ -64,5 +66,12 @@ public class LostItemController {
                 category_id,
                 region
         )));
+    }
+
+    @GetMapping("/items/search/list")
+    public ResponseEntity<ResponseDto<LostItemsListDto>> searchLostItemsList(
+            @RequestBody final LostItemIdsDto lostItemIdsDto
+    ) {
+        return ResponseEntity.ok().body(ResponseDto.success(lostItemService.searchLostItemsList(lostItemIdsDto.ids())));
     }
 }

--- a/src/main/java/org/lostnomore/backend/item/controller/LostItemController.java
+++ b/src/main/java/org/lostnomore/backend/item/controller/LostItemController.java
@@ -8,6 +8,9 @@ import org.lostnomore.backend.item.service.LostItemService;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.lostnomore.backend.item.dto.request.LostItemCreateDto;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
@@ -28,4 +31,11 @@ public class LostItemController {
         return ResponseEntity.status(HttpStatus.OK).body(ResponseDto.success(lostItemService.getRecentItems(userId)));
     }
 
+    @PostMapping("/items")
+    public ResponseEntity<ResponseDto<Void>> saveLostItem(
+            @RequestBody final LostItemCreateDto request
+    ) {
+        lostItemService.saveLostItem(request);
+        return ResponseEntity.ok(ResponseDto.success());
+    }
 }

--- a/src/main/java/org/lostnomore/backend/item/controller/LostItemController.java
+++ b/src/main/java/org/lostnomore/backend/item/controller/LostItemController.java
@@ -4,14 +4,19 @@ import lombok.RequiredArgsConstructor;
 import org.lostnomore.backend.global.dto.ResponseDto;
 import org.lostnomore.backend.item.dto.response.ItemsCountDto;
 import org.lostnomore.backend.item.dto.response.RecentItemsDto;
+import org.lostnomore.backend.item.dto.request.LostItemCreateDto;
+import org.lostnomore.backend.item.dto.response.LostItemsSearchDto;
 import org.lostnomore.backend.item.service.LostItemService;
 import org.springframework.http.HttpStatus;
+import org.springframework.format.annotation.DateTimeFormat;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
-import org.lostnomore.backend.item.dto.request.LostItemCreateDto;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
+
+import java.time.LocalDate;
 
 @RestController
 @RequiredArgsConstructor
@@ -37,5 +42,27 @@ public class LostItemController {
     ) {
         lostItemService.saveLostItem(request);
         return ResponseEntity.ok(ResponseDto.success());
+    }
+
+    @GetMapping("/items/search/map")
+    public ResponseEntity<ResponseDto<LostItemsSearchDto>> searchLostItems(
+            @RequestParam @DateTimeFormat(pattern = "yyyy-MM-dd") LocalDate date_start,
+            @RequestParam @DateTimeFormat(pattern = "yyyy-MM-dd") LocalDate date_end,
+            @RequestParam Double top_left_lat,
+            @RequestParam Double top_left_lon,
+            @RequestParam Double bottom_right_lat,
+            @RequestParam Double bottom_right_lon,
+            @RequestParam(required = false) String keyword,
+            @RequestParam(required = false) Integer category_id,
+            @RequestParam(required = false) String region
+    ) {
+        return ResponseEntity.ok(ResponseDto.success(lostItemService.searchLostItems(
+                date_start, date_end,
+                top_left_lat, top_left_lon,
+                bottom_right_lat, bottom_right_lon,
+                keyword,
+                category_id,
+                region
+        )));
     }
 }

--- a/src/main/java/org/lostnomore/backend/item/domain/Location.java
+++ b/src/main/java/org/lostnomore/backend/item/domain/Location.java
@@ -29,16 +29,16 @@ public class Location {
     private Double latitude;
 
     @Column(name = "longtitude", nullable = false)
-    private Double longtitude;
+    private Double longitude;
 
     @Column(name = "region", nullable = false)
     private String region;
 
     @Builder
-    public Location(String name, Double latitude, Double longtitude, String region) {
+    public Location(String name, Double latitude, Double longitude, String region) {
         this.name = name;
         this.latitude = latitude;
-        this.longtitude = longtitude;
+        this.longitude = longitude;
         this.region = region;
     }
 }

--- a/src/main/java/org/lostnomore/backend/item/dto/request/LostItemCreateDto.java
+++ b/src/main/java/org/lostnomore/backend/item/dto/request/LostItemCreateDto.java
@@ -1,0 +1,16 @@
+package org.lostnomore.backend.item.dto.request;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+
+import java.time.LocalDate;
+
+public record LostItemCreateDto(
+        String name,
+        @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd")
+        LocalDate date,
+        Long categoryId,
+        String location,
+        String color,
+        String image
+) {
+}

--- a/src/main/java/org/lostnomore/backend/item/dto/request/LostItemIdsDto.java
+++ b/src/main/java/org/lostnomore/backend/item/dto/request/LostItemIdsDto.java
@@ -1,0 +1,8 @@
+package org.lostnomore.backend.item.dto.request;
+
+import java.util.List;
+
+public record LostItemIdsDto(
+        List<Long> ids
+) {
+}

--- a/src/main/java/org/lostnomore/backend/item/dto/response/LostItemListDto.java
+++ b/src/main/java/org/lostnomore/backend/item/dto/response/LostItemListDto.java
@@ -1,0 +1,27 @@
+package org.lostnomore.backend.item.dto.response;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+import org.lostnomore.backend.item.domain.LostItem;
+
+import java.time.LocalDate;
+
+public record LostItemListDto(
+        Long id,
+        String name,
+        @JsonFormat(pattern = "yyyy-MM-dd")
+        LocalDate date,
+        String location,
+        String category,
+        String imageUrl
+) {
+    public static LostItemListDto from(LostItem lostItem) {
+        return new LostItemListDto(
+                lostItem.getId(),
+                lostItem.getName(),
+                lostItem.getDate(),
+                lostItem.getLocation().getName(),
+                lostItem.getCategory().getName(),
+                lostItem.getImage()
+        );
+    }
+}

--- a/src/main/java/org/lostnomore/backend/item/dto/response/LostItemsListDto.java
+++ b/src/main/java/org/lostnomore/backend/item/dto/response/LostItemsListDto.java
@@ -1,0 +1,20 @@
+package org.lostnomore.backend.item.dto.response;
+
+import org.lostnomore.backend.item.domain.LostItem;
+
+import java.util.List;
+
+public record LostItemsListDto(
+        int totalCount,
+        List<LostItemListDto> lostItemList
+) {
+    public static LostItemsListDto from (List<LostItem> lostItems) {
+        return new LostItemsListDto(
+                lostItems.size(),
+                lostItems.stream()
+                        .map(LostItemListDto::from)
+                        .toList()
+        );
+    }
+
+}

--- a/src/main/java/org/lostnomore/backend/item/dto/response/LostItemsSearchDto.java
+++ b/src/main/java/org/lostnomore/backend/item/dto/response/LostItemsSearchDto.java
@@ -1,0 +1,36 @@
+package org.lostnomore.backend.item.dto.response;
+
+import org.lostnomore.backend.item.elastic.LostItemDocument;
+import org.springframework.data.elasticsearch.core.SearchHits;
+
+import java.util.List;
+
+public record LostItemsSearchDto(
+        List<LostItemSearchDto> lostItems
+) {
+    public static LostItemsSearchDto from(SearchHits<LostItemDocument> lostItems) {
+        return new LostItemsSearchDto(
+                lostItems.stream()
+                        .map(hit -> new LostItemSearchDto(
+                        hit.getContent().getId(),
+                        hit.getContent().getLocation().getLat(),
+                        hit.getContent().getLocation().getLon()
+                ))
+                        .toList()
+        );
+    }
+
+    public record LostItemSearchDto(
+            Long id,
+            Double latitude,
+            Double longitude
+    ) {
+        public static LostItemSearchDto from (LostItemDocument lostItem) {
+            return new LostItemSearchDto(
+                    lostItem.getId(),
+                    lostItem.getLocation().getLat(),
+                    lostItem.getLocation().getLon()
+            );
+        }
+    }
+}

--- a/src/main/java/org/lostnomore/backend/item/elastic/LostItemDocument.java
+++ b/src/main/java/org/lostnomore/backend/item/elastic/LostItemDocument.java
@@ -18,7 +18,7 @@ public class LostItemDocument {
     @Id
     private Long id;
 
-    @Field(type = FieldType.Text, analyzer = "standard")
+    @Field(type = FieldType.Text, analyzer = "nori")
     private String name;
 
     @Field(type = FieldType.Date)
@@ -33,14 +33,25 @@ public class LostItemDocument {
     @GeoPointField
     private GeoPoint location;
 
+    public LostItemDocument() {
+    }
+
     @Builder
-    public LostItemDocument(Long id, String name, LocalDate date, Long categoryId, String region, Double lat, Double lon) {
+    public LostItemDocument(
+            Long id,
+            String name,
+            LocalDate date,
+            Long categoryId,
+            String region,
+            GeoPoint location
+    ) {
         this.id = id;
         this.name = name;
         this.date = date;
         this.categoryId = categoryId;
         this.region = region;
-        this.location = new GeoPoint(lat, lon);
+        this.location = location;
     }
+
 }
 

--- a/src/main/java/org/lostnomore/backend/item/elastic/LostItemDocument.java
+++ b/src/main/java/org/lostnomore/backend/item/elastic/LostItemDocument.java
@@ -1,0 +1,46 @@
+package org.lostnomore.backend.item.elastic;
+
+import lombok.Builder;
+import lombok.Data;
+import org.springframework.data.annotation.Id;
+import org.springframework.data.elasticsearch.annotations.Document;
+import org.springframework.data.elasticsearch.annotations.Field;
+import org.springframework.data.elasticsearch.annotations.FieldType;
+import org.springframework.data.elasticsearch.annotations.GeoPointField;
+import org.springframework.data.elasticsearch.core.geo.GeoPoint;
+
+import java.time.LocalDate;
+
+@Data
+@Document(indexName = "lost_item")
+public class LostItemDocument {
+
+    @Id
+    private Long id;
+
+    @Field(type = FieldType.Text, analyzer = "standard")
+    private String name;
+
+    @Field(type = FieldType.Date)
+    private LocalDate date;
+
+    @Field(type = FieldType.Long)
+    private Long categoryId;
+
+    @Field(type = FieldType.Text, analyzer = "standard")
+    private String region;
+
+    @GeoPointField
+    private GeoPoint location;
+
+    @Builder
+    public LostItemDocument(Long id, String name, LocalDate date, Long categoryId, String region, Double lat, Double lon) {
+        this.id = id;
+        this.name = name;
+        this.date = date;
+        this.categoryId = categoryId;
+        this.region = region;
+        this.location = new GeoPoint(lat, lon);
+    }
+}
+

--- a/src/main/java/org/lostnomore/backend/item/elastic/LostItemDocument.java
+++ b/src/main/java/org/lostnomore/backend/item/elastic/LostItemDocument.java
@@ -18,7 +18,7 @@ public class LostItemDocument {
     @Id
     private Long id;
 
-    @Field(type = FieldType.Text, analyzer = "nori")
+    @Field(type = FieldType.Text, analyzer = "standard")
     private String name;
 
     @Field(type = FieldType.Date)

--- a/src/main/java/org/lostnomore/backend/item/elastic/LostItemSearchRepository.java
+++ b/src/main/java/org/lostnomore/backend/item/elastic/LostItemSearchRepository.java
@@ -1,0 +1,6 @@
+package org.lostnomore.backend.item.elastic;
+
+import org.springframework.data.elasticsearch.repository.ElasticsearchRepository;
+
+public interface LostItemSearchRepository extends ElasticsearchRepository<LostItemDocument, Long> {
+}

--- a/src/main/java/org/lostnomore/backend/item/elastic/LostItemSearchService.java
+++ b/src/main/java/org/lostnomore/backend/item/elastic/LostItemSearchService.java
@@ -1,0 +1,119 @@
+package org.lostnomore.backend.item.elastic;
+
+import co.elastic.clients.elasticsearch._types.GeoBounds;
+import co.elastic.clients.elasticsearch._types.GeoLocation;
+import co.elastic.clients.elasticsearch._types.query_dsl.*;
+import co.elastic.clients.json.JsonData;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.elasticsearch.client.elc.NativeQuery;
+import org.springframework.data.elasticsearch.core.ElasticsearchOperations;
+import org.springframework.data.elasticsearch.core.SearchHits;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDate;
+import java.util.ArrayList;
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class LostItemSearchService {
+
+    private final ElasticsearchOperations elasticsearchOperations;
+
+    @Transactional(readOnly = true)
+    public SearchHits<LostItemDocument> searchLostItems(
+            LocalDate dateStart,
+            LocalDate dateEnd,
+            Double topLeftLat,
+            Double topLeftLon,
+            Double bottomRightLat,
+            Double bottomRightLon,
+            String keyword,
+            Integer categoryId,
+            String region
+    ) {
+
+        List<Query> mustQueries = new ArrayList<>();
+        List<Query> shouldQueries = new ArrayList<>();
+
+        // 날짜 범위
+        RangeQuery dateRangeQuery = RangeQuery.of(r -> r
+                .field("date")
+                .gte(JsonData.of(dateStart.toString()))
+                .lte(JsonData.of(dateEnd.toString()))
+        );
+        mustQueries.add(dateRangeQuery._toQuery());
+
+        // 키워드 검색
+        boolean hasKeyword = (keyword != null && !keyword.isBlank());
+
+        if (hasKeyword) {
+            // 유사 검색
+            FuzzyQuery fuzzyQuery = FuzzyQuery.of(f -> f
+                    .field("name")
+                    .value(keyword)
+                    .fuzziness("AUTO")
+            );
+            shouldQueries.add(fuzzyQuery._toQuery());
+
+            // 부분 검색
+            PrefixQuery prefixQuery = PrefixQuery.of(p -> p
+                    .field("name")
+                    .value(keyword)
+            );
+            shouldQueries.add(prefixQuery._toQuery());
+        }
+
+        // 카테고리
+        if (categoryId != null) {
+            TermQuery termQuery = TermQuery.of(t -> t
+                    .field("categoryId")
+                    .value(categoryId)
+            );
+            mustQueries.add(termQuery._toQuery());
+        }
+
+        // 지역
+        if (region != null && !region.isBlank()) {
+            MatchQuery regionQuery = MatchQuery.of(m -> m
+                    .field("region")
+                    .query(region)
+            );
+            mustQueries.add(regionQuery._toQuery());
+        }
+
+        // 위치 필터
+        GeoBoundingBoxQuery geoQuery = GeoBoundingBoxQuery.of(g -> g
+                .field("location")
+                .boundingBox(
+                        GeoBounds.of(outer -> outer.tlbr(b -> b
+                                .topLeft(GeoLocation.of(loc ->
+                                        loc.text(topLeftLat + "," + topLeftLon)
+                                ))
+                                .bottomRight(GeoLocation.of(loc ->
+                                        loc.text(bottomRightLat + "," + bottomRightLon)
+                                ))
+                        ))
+                )
+        );
+        mustQueries.add(geoQuery._toQuery());
+
+        BoolQuery.Builder boolQueryBuilder = new BoolQuery.Builder()
+                .must(mustQueries); // 필수 조건 추가
+
+        if (hasKeyword) {
+            boolQueryBuilder.should(shouldQueries);
+            boolQueryBuilder.minimumShouldMatch("1");
+        }
+
+        Query boolQuery = boolQueryBuilder.build()._toQuery();
+
+        NativeQuery searchQuery = NativeQuery.builder()
+                .withQuery(boolQuery)
+                .build();
+
+        return elasticsearchOperations.search(searchQuery, LostItemDocument.class);
+    }
+}

--- a/src/main/java/org/lostnomore/backend/item/manager/CategoryRetriever.java
+++ b/src/main/java/org/lostnomore/backend/item/manager/CategoryRetriever.java
@@ -1,0 +1,18 @@
+package org.lostnomore.backend.item.manager;
+
+import lombok.RequiredArgsConstructor;
+import org.lostnomore.backend.item.domain.Category;
+import org.lostnomore.backend.item.repository.CategoryRepository;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class CategoryRetriever {
+
+    private final CategoryRepository categoryRepository;
+
+    public Category findById(final Long categoryId) {
+        return categoryRepository.findById(categoryId)
+                .orElseThrow(() -> new IllegalArgumentException("해당 Category가 존재하지 않습니다."));
+    }
+}

--- a/src/main/java/org/lostnomore/backend/item/manager/LocationCreator.java
+++ b/src/main/java/org/lostnomore/backend/item/manager/LocationCreator.java
@@ -1,0 +1,17 @@
+package org.lostnomore.backend.item.manager;
+
+import lombok.RequiredArgsConstructor;
+import org.lostnomore.backend.item.domain.Location;
+import org.lostnomore.backend.item.repository.LocationRepository;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class LocationCreator {
+
+    private final LocationRepository locationRepository;
+
+    public Location save(final Location location) {
+        return locationRepository.save(location);
+    }
+}

--- a/src/main/java/org/lostnomore/backend/item/manager/LocationRetriever.java
+++ b/src/main/java/org/lostnomore/backend/item/manager/LocationRetriever.java
@@ -1,0 +1,17 @@
+package org.lostnomore.backend.item.manager;
+
+import lombok.RequiredArgsConstructor;
+import org.lostnomore.backend.item.domain.Location;
+import org.lostnomore.backend.item.repository.LocationRepository;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class LocationRetriever {
+
+    private final LocationRepository locationRepository;
+
+    public Location findByName(final String location) {
+        return locationRepository.findByName(location);
+    }
+}

--- a/src/main/java/org/lostnomore/backend/item/manager/LostItemCreator.java
+++ b/src/main/java/org/lostnomore/backend/item/manager/LostItemCreator.java
@@ -1,0 +1,17 @@
+package org.lostnomore.backend.item.manager;
+
+import lombok.RequiredArgsConstructor;
+import org.lostnomore.backend.item.domain.LostItem;
+import org.lostnomore.backend.item.repository.LostItemRepository;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class LostItemCreator {
+
+    private final LostItemRepository lostItemRepository;
+
+    public LostItem save(final LostItem lostItem) {
+        return lostItemRepository.save(lostItem);
+    }
+}

--- a/src/main/java/org/lostnomore/backend/item/manager/LostItemRetriever.java
+++ b/src/main/java/org/lostnomore/backend/item/manager/LostItemRetriever.java
@@ -3,12 +3,14 @@ package org.lostnomore.backend.item.manager;
 import jakarta.persistence.Tuple;
 import lombok.RequiredArgsConstructor;
 import org.lostnomore.backend.item.domain.LostItem;
+import org.lostnomore.backend.item.dto.request.LostItemIdsDto;
 import org.lostnomore.backend.item.repository.LostItemRepository;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Component;
 
 import java.time.LocalDateTime;
+import java.util.List;
 
 @Component
 @RequiredArgsConstructor
@@ -25,5 +27,9 @@ public class LostItemRetriever {
             final Pageable pageable
     ) {
         return lostItemRepository.findRecentItemsByUserId(userId, pageable);
+    }
+
+    public List<LostItem> findByIdIn(List<Long> ids) {
+        return lostItemRepository.findByIdIn(ids);
     }
 }

--- a/src/main/java/org/lostnomore/backend/item/repository/CategoryRepository.java
+++ b/src/main/java/org/lostnomore/backend/item/repository/CategoryRepository.java
@@ -1,0 +1,7 @@
+package org.lostnomore.backend.item.repository;
+
+import org.lostnomore.backend.item.domain.Category;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface CategoryRepository extends JpaRepository<Category, Long> {
+}

--- a/src/main/java/org/lostnomore/backend/item/repository/LocationRepository.java
+++ b/src/main/java/org/lostnomore/backend/item/repository/LocationRepository.java
@@ -1,0 +1,11 @@
+package org.lostnomore.backend.item.repository;
+
+import org.lostnomore.backend.item.domain.Location;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface LocationRepository extends JpaRepository<Location, Long> {
+
+    Location findByName(String name);
+}

--- a/src/main/java/org/lostnomore/backend/item/repository/LostItemRepository.java
+++ b/src/main/java/org/lostnomore/backend/item/repository/LostItemRepository.java
@@ -2,6 +2,7 @@ package org.lostnomore.backend.item.repository;
 
 import jakarta.persistence.Tuple;
 import org.lostnomore.backend.item.domain.LostItem;
+import org.lostnomore.backend.item.dto.request.LostItemIdsDto;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -9,6 +10,7 @@ import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
 import java.time.LocalDateTime;
+import java.util.List;
 
 public interface LostItemRepository extends JpaRepository<LostItem, Long> {
 
@@ -30,4 +32,12 @@ public interface LostItemRepository extends JpaRepository<LostItem, Long> {
        """)
     Page<LostItem> findRecentItemsByUserId(Long userId, Pageable pageable);
 
+
+    @Query("""
+       SELECT l FROM LostItem l
+       JOIN FETCH l.location
+       JOIN FETCH l.category
+       WHERE l.id IN :ids
+       """)
+    List<LostItem> findByIdIn(List<Long> ids);
 }

--- a/src/main/java/org/lostnomore/backend/item/service/LostItemService.java
+++ b/src/main/java/org/lostnomore/backend/item/service/LostItemService.java
@@ -5,8 +5,11 @@ import org.lostnomore.backend.item.domain.Category;
 import org.lostnomore.backend.item.domain.Location;
 import org.lostnomore.backend.item.domain.LostItem;
 import org.lostnomore.backend.item.dto.request.LostItemCreateDto;
+import org.lostnomore.backend.item.dto.response.LostItemsSearchDto;
 import org.lostnomore.backend.item.elastic.LostItemDocument;
 import org.lostnomore.backend.item.elastic.LostItemSearchRepository;
+import org.lostnomore.backend.item.elastic.LostItemSearchService;
+import org.lostnomore.backend.item.manager.*;
 import org.lostnomore.backend.item.repository.CategoryRepository;
 import org.lostnomore.backend.item.repository.LocationRepository;
 import org.lostnomore.backend.item.repository.LostItemRepository;
@@ -27,10 +30,12 @@ import java.util.List;
 public class LostItemService {
 
     private final LostItemRetriever lostItemRetriever;
-    private final LostItemRepository lostItemRepository;
+    private final CategoryRetriever categoryRetriever;
+    private final LocationRetriever locationRetriever;
+    private final LocationCreator locationCreator;
+    private final LostItemCreator lostItemCreator;
     private final LostItemSearchRepository lostItemSearchRepository;
-    private final LocationRepository locationRepository;
-    private final CategoryRepository categoryRepository;
+    private final LostItemSearchService lostItemSearchService;
 
     @Transactional(readOnly = true)
     public ItemsCountDto getItemsCount() {
@@ -54,11 +59,13 @@ public class LostItemService {
     public void saveLostItem(LostItemCreateDto request) {
         Category category = categoryRepository.findById(request.categoryId())
                 .orElseThrow(() -> new IllegalArgumentException("해당 Category가 존재하지 않습니다."));
+    public void saveLostItem(final LostItemCreateDto request) {
+        Category category = categoryRetriever.findById(request.categoryId());
 
-        Location location = locationRepository.findByName(request.location());
+        Location location = locationRetriever.findByName(request.location());
 
         if (location == null) {
-            location = locationRepository.save(Location.builder()
+            location = locationCreator.save(Location.builder()
                     .name(request.location())
                     .region("부산")
                     .longitude(129.0756)
@@ -66,7 +73,7 @@ public class LostItemService {
                     .build());
         }
 
-        LostItem savedItem = lostItemRepository.save(LostItem.builder()
+        LostItem savedItem = lostItemCreator.save(LostItem.builder()
                 .name(request.name())
                 .date(request.date())
                 .category(category)

--- a/src/main/java/org/lostnomore/backend/item/service/LostItemService.java
+++ b/src/main/java/org/lostnomore/backend/item/service/LostItemService.java
@@ -10,15 +10,13 @@ import org.lostnomore.backend.item.elastic.LostItemDocument;
 import org.lostnomore.backend.item.elastic.LostItemSearchRepository;
 import org.lostnomore.backend.item.elastic.LostItemSearchService;
 import org.lostnomore.backend.item.manager.*;
-import org.lostnomore.backend.item.repository.CategoryRepository;
-import org.lostnomore.backend.item.repository.LocationRepository;
-import org.lostnomore.backend.item.repository.LostItemRepository;
 import jakarta.persistence.Tuple;
 import org.lostnomore.backend.item.dto.response.ItemsCountDto;
 import org.lostnomore.backend.item.dto.response.RecentItemsDto;
-import org.lostnomore.backend.item.manager.LostItemRetriever;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.elasticsearch.core.SearchHits;
+import org.springframework.data.elasticsearch.core.geo.GeoPoint;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -56,9 +54,6 @@ public class LostItemService {
     }
 
     @Transactional
-    public void saveLostItem(LostItemCreateDto request) {
-        Category category = categoryRepository.findById(request.categoryId())
-                .orElseThrow(() -> new IllegalArgumentException("해당 Category가 존재하지 않습니다."));
     public void saveLostItem(final LostItemCreateDto request) {
         Category category = categoryRetriever.findById(request.categoryId());
 
@@ -88,10 +83,32 @@ public class LostItemService {
                 .date(savedItem.getDate())
                 .categoryId(savedItem.getCategory().getId())
                 .region(savedItem.getLocation().getRegion())
-                .lat(savedItem.getLocation().getLatitude())
-                .lon(savedItem.getLocation().getLongitude())
+                .location(
+                        new GeoPoint(
+                                savedItem.getLocation().getLatitude(),
+                                savedItem.getLocation().getLongitude()
+                        )
+                )
                 .build();
 
         lostItemSearchRepository.save(document);
+    }
+
+    @Transactional(readOnly = true)
+    public LostItemsSearchDto searchLostItems(
+            LocalDate dateStart, LocalDate dateEnd,
+            Double topLeftLat, Double topLeftLon,
+            Double bottomRightLat, Double bottomRightLon,
+            String keyword, Integer categoryId, String region
+    ) {
+
+        SearchHits<LostItemDocument> lostItems = lostItemSearchService.searchLostItems(
+                dateStart, dateEnd,
+                topLeftLat, topLeftLon,
+                bottomRightLat, bottomRightLon,
+                keyword, categoryId, region
+        );
+
+        return LostItemsSearchDto.from(lostItems);
     }
 }

--- a/src/main/java/org/lostnomore/backend/item/service/LostItemService.java
+++ b/src/main/java/org/lostnomore/backend/item/service/LostItemService.java
@@ -1,10 +1,13 @@
 package org.lostnomore.backend.item.service;
 
 import lombok.RequiredArgsConstructor;
+import org.lostnomore.backend.global.dto.ResponseDto;
 import org.lostnomore.backend.item.domain.Category;
 import org.lostnomore.backend.item.domain.Location;
 import org.lostnomore.backend.item.domain.LostItem;
 import org.lostnomore.backend.item.dto.request.LostItemCreateDto;
+import org.lostnomore.backend.item.dto.request.LostItemIdsDto;
+import org.lostnomore.backend.item.dto.response.LostItemsListDto;
 import org.lostnomore.backend.item.dto.response.LostItemsSearchDto;
 import org.lostnomore.backend.item.elastic.LostItemDocument;
 import org.lostnomore.backend.item.elastic.LostItemSearchRepository;
@@ -17,6 +20,7 @@ import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.elasticsearch.core.SearchHits;
 import org.springframework.data.elasticsearch.core.geo.GeoPoint;
+import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -110,5 +114,10 @@ public class LostItemService {
         );
 
         return LostItemsSearchDto.from(lostItems);
+    }
+
+    @Transactional(readOnly = true)
+    public LostItemsListDto searchLostItemsList(final List<Long> ids) {
+        return LostItemsListDto.from(lostItemRetriever.findByIdIn(ids));
     }
 }

--- a/src/main/java/org/lostnomore/backend/item/service/LostItemService.java
+++ b/src/main/java/org/lostnomore/backend/item/service/LostItemService.java
@@ -1,8 +1,16 @@
 package org.lostnomore.backend.item.service;
 
-import jakarta.persistence.Tuple;
 import lombok.RequiredArgsConstructor;
+import org.lostnomore.backend.item.domain.Category;
+import org.lostnomore.backend.item.domain.Location;
 import org.lostnomore.backend.item.domain.LostItem;
+import org.lostnomore.backend.item.dto.request.LostItemCreateDto;
+import org.lostnomore.backend.item.elastic.LostItemDocument;
+import org.lostnomore.backend.item.elastic.LostItemSearchRepository;
+import org.lostnomore.backend.item.repository.CategoryRepository;
+import org.lostnomore.backend.item.repository.LocationRepository;
+import org.lostnomore.backend.item.repository.LostItemRepository;
+import jakarta.persistence.Tuple;
 import org.lostnomore.backend.item.dto.response.ItemsCountDto;
 import org.lostnomore.backend.item.dto.response.RecentItemsDto;
 import org.lostnomore.backend.item.manager.LostItemRetriever;
@@ -36,5 +44,48 @@ public class LostItemService {
         List<LostItem> recentItems = lostItemRetriever.findRecentItemsByUserId(userId, pageable).getContent();
 
         return RecentItemsDto.from(recentItems);
+    }
+
+    private final LostItemRepository lostItemRepository;
+    private final LostItemSearchRepository lostItemSearchRepository;
+    private final LocationRepository locationRepository;
+    private final CategoryRepository categoryRepository;
+
+    @Transactional
+    public void saveLostItem(LostItemCreateDto request) {
+        Category category = categoryRepository.findById(request.categoryId())
+                .orElseThrow(() -> new IllegalArgumentException("해당 Category가 존재하지 않습니다."));
+
+        Location location = locationRepository.findByName(request.location());
+
+        if (location == null) {
+            location = locationRepository.save(Location.builder()
+                    .name(request.location())
+                    .region("부산")
+                    .longitude(129.0756)
+                    .latitude(35.1796)
+                    .build());
+        }
+
+        LostItem savedItem = lostItemRepository.save(LostItem.builder()
+                .name(request.name())
+                .date(request.date())
+                .category(category)
+                .location(location)
+                .color(request.color())
+                .image(request.image())
+                .build());
+
+        LostItemDocument document = LostItemDocument.builder()
+                .id(savedItem.getId())
+                .name(savedItem.getName())
+                .date(savedItem.getDate())
+                .categoryId(savedItem.getCategory().getId())
+                .region(savedItem.getLocation().getRegion())
+                .lat(savedItem.getLocation().getLatitude())
+                .lon(savedItem.getLocation().getLongitude())
+                .build();
+
+        lostItemSearchRepository.save(document);
     }
 }

--- a/src/main/java/org/lostnomore/backend/item/service/LostItemService.java
+++ b/src/main/java/org/lostnomore/backend/item/service/LostItemService.java
@@ -27,6 +27,10 @@ import java.util.List;
 public class LostItemService {
 
     private final LostItemRetriever lostItemRetriever;
+    private final LostItemRepository lostItemRepository;
+    private final LostItemSearchRepository lostItemSearchRepository;
+    private final LocationRepository locationRepository;
+    private final CategoryRepository categoryRepository;
 
     @Transactional(readOnly = true)
     public ItemsCountDto getItemsCount() {
@@ -45,11 +49,6 @@ public class LostItemService {
 
         return RecentItemsDto.from(recentItems);
     }
-
-    private final LostItemRepository lostItemRepository;
-    private final LostItemSearchRepository lostItemSearchRepository;
-    private final LocationRepository locationRepository;
-    private final CategoryRepository categoryRepository;
 
     @Transactional
     public void saveLostItem(LostItemCreateDto request) {

--- a/src/test/java/org/lostnomore/backend/item/controller/LostItemControllerTest.java
+++ b/src/test/java/org/lostnomore/backend/item/controller/LostItemControllerTest.java
@@ -1,0 +1,74 @@
+package org.lostnomore.backend.item.controller;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.lostnomore.backend.common.ControllerTest;
+import org.lostnomore.backend.item.dto.response.LostItemsSearchDto;
+import org.lostnomore.backend.item.service.LostItemService;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+
+import java.time.LocalDate;
+import java.util.List;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(LostItemController.class)
+class LostItemControllerTest extends ControllerTest {
+
+    @InjectMocks
+    private LostItemController lostItemController;
+
+    @MockitoBean
+    private LostItemService lostItemService;
+
+    @Test
+    @DisplayName("분실물 검색 API 호출 시 200 응답을 반환한다.")
+    void testSearchLostItems() throws Exception {
+        // given
+        LocalDate localDate = LocalDate.of(2024, 2, 1);
+        LocalDate endDate = LocalDate.of(2024, 2, 10);
+
+        LostItemsSearchDto mockResponse = new LostItemsSearchDto(List.of(
+                new LostItemsSearchDto.LostItemSearchDto(1L, 37.57, 126.98),
+                new LostItemsSearchDto.LostItemSearchDto(2L, 37.55, 127.00)
+        ));
+
+        when(lostItemService.searchLostItems(any(), any(), any(), any(), any(), any(), any(), any(), any()))
+                .thenReturn(mockResponse);
+
+        // when & then
+        mockMvc.perform(get("/items/search/map")
+                        .param("date_start", "2024-02-01")
+                        .param("date_end", "2024-02-10")
+                        .param("top_left_lat", "37.57")
+                        .param("top_left_lon", "126.98")
+                        .param("bottom_right_lat", "37.55")
+                        .param("bottom_right_lon", "127.00"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.isSuccess").value(true))
+                .andExpect(jsonPath("$.data.lostItems[0].id").value(1L))
+                .andExpect(jsonPath("$.data.lostItems[0].latitude").value(37.57))
+                .andExpect(jsonPath("$.data.lostItems[0].longitude").value(126.98))
+                .andExpect(jsonPath("$.data.lostItems[1].id").value(2L))
+                .andExpect(jsonPath("$.data.lostItems[1].latitude").value(37.55))
+                .andExpect(jsonPath("$.data.lostItems[1].longitude").value(127.00));
+    }
+
+
+
+
+}

--- a/src/test/java/org/lostnomore/backend/item/service/LostItemServiceTest.java
+++ b/src/test/java/org/lostnomore/backend/item/service/LostItemServiceTest.java
@@ -5,16 +5,23 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.lostnomore.backend.item.dto.response.ItemsCountDto;
+import org.lostnomore.backend.item.dto.response.LostItemsSearchDto;
+import org.lostnomore.backend.item.elastic.LostItemSearchService;
 import org.lostnomore.backend.item.manager.LostItemRetriever;
 import org.lostnomore.backend.item.repository.LostItemRepository;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.elasticsearch.core.SearchHits;
 
 import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -26,6 +33,9 @@ class LostItemServiceTest {
 
     @Mock
     private LostItemRetriever lostItemRetriever;
+
+    @Mock
+    private LostItemSearchService lostItemSearchService;
 
     @InjectMocks
     private LostItemService lostItemService;
@@ -66,6 +76,25 @@ class LostItemServiceTest {
         // Then
         assertThat(result.today()).isEqualTo(0);
         assertThat(result.total()).isEqualTo(0);
+    }
+
+    @Test
+    @DisplayName("검색 결과를 정상적으로 반환해야 한다.")
+    void testSearchLostItems() {
+        // given
+        LocalDate startDate = LocalDate.of(2024, 2, 1);
+        LocalDate endDate = LocalDate.of(2024, 2, 10);
+
+        when(lostItemSearchService.searchLostItems(any(), any(), any(), any(), any(), any(), any(), any(), any()))
+                .thenReturn(mock(SearchHits.class)); // 그냥 빈 Mock 객체 반환
+
+        // when
+        LostItemsSearchDto result = lostItemService.searchLostItems(
+                startDate, endDate, 37.57, 126.98, 37.55, 127.00, null, null, null);
+
+        // then
+        assertNotNull(result);
+        assertEquals(0, result.lostItems().size());
     }
 
 }


### PR DESCRIPTION
## Related issue 🛠
[//]: # (해당하는 이슈 번호 달아주기)
- closed #19 

## Work Description ✏️
[//]: # (작업 내용 간단 소개)
- Elasticsearch를 활용한 검색 기능을 구현하였습니다.
  - **유사 검색**: 예를 들어, `강아지모자`를 검색하면 `강아지모차`도 검색될 수 있도록 설정
  - **부분 검색**: `강아지`, `강아지모` 등 일부 단어만 입력해도 검색 가능
- 밑에 강아지모차, 강아지모자, 강아지모 모두 검색되는 사진 첨부하였습니다.
<img width="707" alt="image" src="https://github.com/user-attachments/assets/81cfd809-07a4-4759-94cf-6db54886676b" />
<img width="705" alt="image" src="https://github.com/user-attachments/assets/5fb78179-3276-4c51-a893-22983b96a645" />
<img width="706" alt="image" src="https://github.com/user-attachments/assets/0d5d6f4f-f17a-4593-927c-118fc55d55e0" />

- Elasticsearch 구현 과정에서 Kibana를 활용하기 위해 도커에 Kibana 컨테이너를 추가하였습니다.

## Uncompleted Tasks 😅
[//]: # (없다면 N/A)
- [ ] 현재 분실물 데이터 적재 로직이 없어, 테스트용으로 하드코딩된 위도/경도 데이터를 저장하는 API를 임시로 구현하였습니다. 적재 로직이 추가되면 해당 API를 제거할 예정입니다.

## To Reviewers 📢
[//]: # (reviewer가 알면 좋은 내용들)
- Kibana 컨테이너 추가로 인해 서버 부하에 미치는 영향을 추후 함께 점검하면 좋을 것 같습니다.