### PR TITLE
[FEAT] 분실물 검색 기능 추가 구현 

### DIFF
--- a/src/main/java/org/lostnomore/backend/global/exception/code/ItemErrorCode.java
+++ b/src/main/java/org/lostnomore/backend/global/exception/code/ItemErrorCode.java
@@ -8,7 +8,7 @@ import org.springframework.http.HttpStatus;
 @AllArgsConstructor
 public enum ItemErrorCode implements DefaultErrorCode {
     //404 BAD_REQUEST
-    ITEM_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 아이템을 찾을 수 없습니다."),
+    ITEM_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 분실물을 찾을 수 없습니다."),
     ;
 
     private HttpStatus httpStatus;

--- a/src/main/java/org/lostnomore/backend/item/controller/LostItemController.java
+++ b/src/main/java/org/lostnomore/backend/item/controller/LostItemController.java
@@ -3,11 +3,8 @@ package org.lostnomore.backend.item.controller;
 import lombok.RequiredArgsConstructor;
 import org.lostnomore.backend.global.dto.ResponseDto;
 import org.lostnomore.backend.item.dto.request.LostItemIdsDto;
-import org.lostnomore.backend.item.dto.response.ItemsCountDto;
-import org.lostnomore.backend.item.dto.response.LostItemsListDto;
-import org.lostnomore.backend.item.dto.response.RecentItemsDto;
+import org.lostnomore.backend.item.dto.response.*;
 import org.lostnomore.backend.item.dto.request.LostItemCreateDto;
-import org.lostnomore.backend.item.dto.response.LostItemsSearchDto;
 import org.lostnomore.backend.item.service.LostItemService;
 import org.springframework.http.HttpStatus;
 import org.springframework.format.annotation.DateTimeFormat;
@@ -73,5 +70,12 @@ public class LostItemController {
             @RequestBody final LostItemIdsDto lostItemIdsDto
     ) {
         return ResponseEntity.ok().body(ResponseDto.success(lostItemService.searchLostItemsList(lostItemIdsDto.ids())));
+    }
+
+    @GetMapping("/items/search/{lostItemId}")
+    public ResponseEntity<ResponseDto<LostItemDto>> getLostItem (
+            @PathVariable final Long lostItemId
+    ) {
+        return ResponseEntity.ok().body(ResponseDto.success(lostItemService.getLostItem(lostItemId)));
     }
 }

--- a/src/main/java/org/lostnomore/backend/item/dto/response/LostItemDto.java
+++ b/src/main/java/org/lostnomore/backend/item/dto/response/LostItemDto.java
@@ -1,0 +1,29 @@
+package org.lostnomore.backend.item.dto.response;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+import org.lostnomore.backend.item.domain.LostItem;
+
+import java.time.LocalDate;
+
+public record LostItemDto(
+        Long id,
+        String name,
+        @JsonFormat(pattern = "yyyy-MM-dd")
+        LocalDate date,
+        String location,
+        Double latitude,
+        Double longitude,
+        String imageUrl
+) {
+    public static LostItemDto from(LostItem lostItem) {
+        return new LostItemDto(
+                lostItem.getId(),
+                lostItem.getName(),
+                lostItem.getDate(),
+                lostItem.getLocation().getName(),
+                lostItem.getLocation().getLatitude(),
+                lostItem.getLocation().getLongitude(),
+                lostItem.getImage()
+        );
+    }
+}

--- a/src/main/java/org/lostnomore/backend/item/dto/response/LostItemDto.java
+++ b/src/main/java/org/lostnomore/backend/item/dto/response/LostItemDto.java
@@ -10,6 +10,7 @@ public record LostItemDto(
         String name,
         @JsonFormat(pattern = "yyyy-MM-dd")
         LocalDate date,
+        String category,
         String location,
         Double latitude,
         Double longitude,
@@ -20,6 +21,7 @@ public record LostItemDto(
                 lostItem.getId(),
                 lostItem.getName(),
                 lostItem.getDate(),
+                lostItem.getCategory().getName(),
                 lostItem.getLocation().getName(),
                 lostItem.getLocation().getLatitude(),
                 lostItem.getLocation().getLongitude(),

--- a/src/main/java/org/lostnomore/backend/item/manager/LostItemRetriever.java
+++ b/src/main/java/org/lostnomore/backend/item/manager/LostItemRetriever.java
@@ -2,6 +2,8 @@ package org.lostnomore.backend.item.manager;
 
 import jakarta.persistence.Tuple;
 import lombok.RequiredArgsConstructor;
+import org.lostnomore.backend.global.exception.BusinessException;
+import org.lostnomore.backend.global.exception.code.ItemErrorCode;
 import org.lostnomore.backend.item.domain.LostItem;
 import org.lostnomore.backend.item.dto.request.LostItemIdsDto;
 import org.lostnomore.backend.item.repository.LostItemRepository;
@@ -31,5 +33,10 @@ public class LostItemRetriever {
 
     public List<LostItem> findByIdIn(List<Long> ids) {
         return lostItemRepository.findByIdIn(ids);
+    }
+
+    public LostItem findById(final Long lostItemId) {
+        return lostItemRepository.findById(lostItemId)
+                .orElseThrow(() -> new BusinessException(ItemErrorCode.ITEM_NOT_FOUND));
     }
 }

--- a/src/main/java/org/lostnomore/backend/item/repository/LostItemRepository.java
+++ b/src/main/java/org/lostnomore/backend/item/repository/LostItemRepository.java
@@ -11,6 +11,7 @@ import org.springframework.data.repository.query.Param;
 
 import java.time.LocalDateTime;
 import java.util.List;
+import java.util.Optional;
 
 public interface LostItemRepository extends JpaRepository<LostItem, Long> {
 
@@ -40,4 +41,11 @@ public interface LostItemRepository extends JpaRepository<LostItem, Long> {
        WHERE l.id IN :ids
        """)
     List<LostItem> findByIdIn(List<Long> ids);
+
+    @Query("""
+      SELECT l FROM LostItem l
+      JOIN FETCH l.location
+      WHERE l.id = :lostItemId
+      """)
+    Optional<LostItem> findById(Long lostItemId);
 }

--- a/src/main/java/org/lostnomore/backend/item/repository/LostItemRepository.java
+++ b/src/main/java/org/lostnomore/backend/item/repository/LostItemRepository.java
@@ -45,6 +45,7 @@ public interface LostItemRepository extends JpaRepository<LostItem, Long> {
     @Query("""
       SELECT l FROM LostItem l
       JOIN FETCH l.location
+      JOIN FETCH l.category
       WHERE l.id = :lostItemId
       """)
     Optional<LostItem> findById(Long lostItemId);

--- a/src/main/java/org/lostnomore/backend/item/service/LostItemService.java
+++ b/src/main/java/org/lostnomore/backend/item/service/LostItemService.java
@@ -7,15 +7,12 @@ import org.lostnomore.backend.item.domain.Location;
 import org.lostnomore.backend.item.domain.LostItem;
 import org.lostnomore.backend.item.dto.request.LostItemCreateDto;
 import org.lostnomore.backend.item.dto.request.LostItemIdsDto;
-import org.lostnomore.backend.item.dto.response.LostItemsListDto;
-import org.lostnomore.backend.item.dto.response.LostItemsSearchDto;
+import org.lostnomore.backend.item.dto.response.*;
 import org.lostnomore.backend.item.elastic.LostItemDocument;
 import org.lostnomore.backend.item.elastic.LostItemSearchRepository;
 import org.lostnomore.backend.item.elastic.LostItemSearchService;
 import org.lostnomore.backend.item.manager.*;
 import jakarta.persistence.Tuple;
-import org.lostnomore.backend.item.dto.response.ItemsCountDto;
-import org.lostnomore.backend.item.dto.response.RecentItemsDto;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.elasticsearch.core.SearchHits;
@@ -119,5 +116,9 @@ public class LostItemService {
     @Transactional(readOnly = true)
     public LostItemsListDto searchLostItemsList(final List<Long> ids) {
         return LostItemsListDto.from(lostItemRetriever.findByIdIn(ids));
+    }
+
+    public LostItemDto getLostItem(final Long lostItemId) {
+        return LostItemDto.from(lostItemRetriever.findById(lostItemId));
     }
 }


### PR DESCRIPTION
## Related issue 🛠
[//]: # (해당하는 이슈 번호 달아주기)
- closed #27 

## Work Description ✏️
[//]: # (작업 내용 간단 소개)
- 분실물 상세 검색 api 구현했습니다.

## Uncompleted Tasks 😅
[//]: # (없다면 N/A)
- [ ] N/A

## To Reviewers 📢
[//]: # (reviewer가 알면 좋은 내용들)
원래 최신 분실물 조회도 같은 pr에 올리려고 하였으나,
분실물 알림 리스트와 같이 구현하는 것이 좋다고 판단하여 따로 이슈 파서 올리겠습니다!