### PR TITLE
[FEAT] 인증/인가 Interceptor 및 ArgumentResolver 생성

### DIFF
--- a/src/main/java/org/lostnomore/backend/auth/provider/JwtTokenProvider.java
+++ b/src/main/java/org/lostnomore/backend/auth/provider/JwtTokenProvider.java
@@ -66,12 +66,7 @@ public class JwtTokenProvider {
                 .compact();
     }
 
-    public void validateTokens(final String accessToken, final String refreshToken) {
-        validateAccessToken(accessToken);
-        validateRefreshToken(refreshToken);
-    }
-
-    private void validateAccessToken(final String accessToken) {
+    public void validateAccessToken(final String accessToken) {
         try {
             parseToken(accessToken);
         } catch (final ExpiredJwtException e) {
@@ -81,7 +76,7 @@ public class JwtTokenProvider {
         }
     }
 
-    private void validateRefreshToken(final String refreshToken) {
+    public void validateRefreshToken(final String refreshToken) {
         try {
             parseToken(refreshToken);
         } catch (final ExpiredJwtException e) {
@@ -102,6 +97,22 @@ public class JwtTokenProvider {
                 .setSigningKey(key)
                 .build()
                 .parseClaimsJws(token);
+    }
+    public Long getExpiredSubject(final String token) {
+        Claims claims = getClaimsFromExpiredToken(token);
+        return claims.get("userId", Long.class);
+    }
+
+    private Claims getClaimsFromExpiredToken(final String token) {
+        try {
+            return Jwts.parserBuilder()
+                    .setSigningKey(key)
+                    .build()
+                    .parseClaimsJws(token)
+                    .getBody();
+        } catch (ExpiredJwtException e) {
+            return e.getClaims();
+        }
     }
 
     public boolean isValidRefreshAndInvalidAccess(final String refreshToken, final String accessToken) {

--- a/src/main/java/org/lostnomore/backend/auth/service/AuthService.java
+++ b/src/main/java/org/lostnomore/backend/auth/service/AuthService.java
@@ -1,7 +1,5 @@
 package org.lostnomore.backend.auth.service;
 
-import static org.lostnomore.backend.global.exception.code.AuthErrorCode.FAIL_TO_VALIDATE_TOKEN;
-
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.lostnomore.backend.auth.domain.RefreshToken;
@@ -59,30 +57,25 @@ public class AuthService {
         return loginToken;
     }
 
-    public UserTokenDto reissue(String refreshTokenRequest, String authorizationHeader) {
-        final String accessToken = bearerExtractor.extractAccessToken(authorizationHeader);
+    public UserTokenDto reissue(String refreshTokenRequest, String requestHeader) {
+        jwtTokenProvider.validateRefreshToken(refreshTokenRequest);
+        String expiredAccessToken = bearerExtractor.extractAccessToken(requestHeader);
 
-        if (jwtTokenProvider.isValidRefreshAndInvalidAccess(refreshTokenRequest, accessToken)) {
-            final RefreshToken refreshToken = refreshTokenRepository.findById(refreshTokenRequest)
-                    .orElseThrow(() -> new BusinessException(AuthErrorCode.INVALID_REFRESH_TOKEN));
+        final RefreshToken refreshToken = refreshTokenRepository.findById(refreshTokenRequest)
+                .orElseThrow(() -> new BusinessException(AuthErrorCode.INVALID_REFRESH_TOKEN));
 
-            Long userId = refreshToken.getUserId();
+        Long userId = jwtTokenProvider.getExpiredSubject(expiredAccessToken);
 
-            String regeneratedAccessToken = jwtTokenProvider.regenerateAccessToken(userId);
-            String regeneratedRefreshToken = jwtTokenProvider.regenerateRefreshToken(userId);
-
-            refreshTokenRepository.deleteById(refreshTokenRequest);
-
-            RefreshToken savedRefreshToken = new RefreshToken(regeneratedRefreshToken, userId);
-            refreshTokenRepository.save(savedRefreshToken);
-
-            return new UserTokenDto(regeneratedAccessToken, regeneratedRefreshToken);
+        if (!refreshToken.getUserId().equals(userId)) {
+            throw new BusinessException(AuthErrorCode.INVALID_REFRESH_TOKEN);
         }
 
-        if (jwtTokenProvider.isValidRefreshAndValidAccess(refreshTokenRequest, accessToken)) {
-            return new UserTokenDto(accessToken, null);
-        }
+        String regeneratedAccessToken = jwtTokenProvider.regenerateAccessToken(userId);
+        String regeneratedRefreshToken = jwtTokenProvider.regenerateRefreshToken(userId);
 
-        throw new BusinessException(FAIL_TO_VALIDATE_TOKEN);
+        refreshTokenRepository.deleteById(refreshTokenRequest);
+        refreshTokenRepository.save(new RefreshToken(regeneratedRefreshToken, userId));
+
+        return new UserTokenDto(regeneratedAccessToken, regeneratedRefreshToken);
     }
 }

--- a/src/main/java/org/lostnomore/backend/global/LoginUser.java
+++ b/src/main/java/org/lostnomore/backend/global/LoginUser.java
@@ -1,0 +1,13 @@
+package org.lostnomore.backend.global;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target({ElementType.PARAMETER, ElementType.ANNOTATION_TYPE})
+@Retention(RetentionPolicy.RUNTIME)
+public @interface LoginUser {
+
+    boolean required() default true;
+}

--- a/src/main/java/org/lostnomore/backend/global/config/WebMvcConfig.java
+++ b/src/main/java/org/lostnomore/backend/global/config/WebMvcConfig.java
@@ -1,0 +1,34 @@
+package org.lostnomore.backend.global.config;
+
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.lostnomore.backend.auth.provider.JwtTokenProvider;
+import org.lostnomore.backend.auth.util.BearerAuthorizationExtractor;
+import org.lostnomore.backend.global.interceptor.AccessTokenInterceptor;
+import org.lostnomore.backend.global.resolver.AccessTokenArgumentResolver;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.servlet.config.annotation.InterceptorRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+@Configuration
+@RequiredArgsConstructor
+public class WebMvcConfig implements WebMvcConfigurer {
+
+    private final JwtTokenProvider jwtTokenProvider;
+    private final BearerAuthorizationExtractor bearerAuthorizationExtractor;
+    private final AccessTokenArgumentResolver accessTokenArgumentResolver;
+    @Override
+    public void addInterceptors(InterceptorRegistry registry) {
+        registry.addInterceptor(new AccessTokenInterceptor(jwtTokenProvider, bearerAuthorizationExtractor))
+                .addPathPatterns("/**")
+                .excludePathPatterns(
+                        "/auth/**"
+                );
+    }
+
+    @Override
+    public void addArgumentResolvers(List<HandlerMethodArgumentResolver> resolvers) {
+        resolvers.add(accessTokenArgumentResolver);
+    }
+}

--- a/src/main/java/org/lostnomore/backend/global/dto/LoginUserDto.java
+++ b/src/main/java/org/lostnomore/backend/global/dto/LoginUserDto.java
@@ -1,7 +1,0 @@
-package org.lostnomore.backend.global.dto;
-
-public record LoginUserDto (
-        Long userId
-){
-
-}

--- a/src/main/java/org/lostnomore/backend/global/dto/LoginUserDto.java
+++ b/src/main/java/org/lostnomore/backend/global/dto/LoginUserDto.java
@@ -1,0 +1,7 @@
+package org.lostnomore.backend.global.dto;
+
+public record LoginUserDto (
+        Long userId
+){
+
+}

--- a/src/main/java/org/lostnomore/backend/global/interceptor/AccessTokenInterceptor.java
+++ b/src/main/java/org/lostnomore/backend/global/interceptor/AccessTokenInterceptor.java
@@ -1,0 +1,28 @@
+package org.lostnomore.backend.global.interceptor;
+
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import org.lostnomore.backend.auth.provider.JwtTokenProvider;
+import org.lostnomore.backend.auth.util.BearerAuthorizationExtractor;
+import org.springframework.stereotype.Component;
+import org.springframework.web.servlet.HandlerInterceptor;
+
+@Component
+@RequiredArgsConstructor
+public class AccessTokenInterceptor implements HandlerInterceptor {
+
+    private final JwtTokenProvider jwtTokenProvider;
+    private final BearerAuthorizationExtractor bearerAuthorizationExtractor;
+
+    @Override
+    public boolean preHandle(HttpServletRequest request, HttpServletResponse response, Object handler) throws Exception {
+        String accessToken = bearerAuthorizationExtractor.extractAccessToken(request.getHeader("Authorization"));
+
+        if (accessToken != null) {
+            jwtTokenProvider.validateAccessToken(accessToken);
+        }
+
+        return true;
+    }
+}

--- a/src/main/java/org/lostnomore/backend/global/resolver/AccessTokenArgumentResolver.java
+++ b/src/main/java/org/lostnomore/backend/global/resolver/AccessTokenArgumentResolver.java
@@ -5,7 +5,6 @@ import lombok.RequiredArgsConstructor;
 import org.lostnomore.backend.auth.provider.JwtTokenProvider;
 import org.lostnomore.backend.auth.util.BearerAuthorizationExtractor;
 import org.lostnomore.backend.global.LoginUser;
-import org.lostnomore.backend.global.dto.LoginUserDto;
 import org.springframework.core.MethodParameter;
 import org.springframework.stereotype.Component;
 import org.springframework.web.bind.support.WebDataBinderFactory;
@@ -29,8 +28,6 @@ public class AccessTokenArgumentResolver implements HandlerMethodArgumentResolve
     public Object resolveArgument(MethodParameter parameter, ModelAndViewContainer mavContainer, NativeWebRequest webRequest, WebDataBinderFactory binderFactory) throws Exception {
         HttpServletRequest request = webRequest.getNativeRequest(HttpServletRequest.class);
         String accessToken = bearerAuthorizationExtractor.extractAccessToken(request.getHeader("Authorization"));
-        Long userId = jwtTokenProvider.getSubject(accessToken);
-
-        return new LoginUserDto(userId);
+        return jwtTokenProvider.getSubject(accessToken);
     }
 }

--- a/src/main/java/org/lostnomore/backend/global/resolver/AccessTokenArgumentResolver.java
+++ b/src/main/java/org/lostnomore/backend/global/resolver/AccessTokenArgumentResolver.java
@@ -1,0 +1,36 @@
+package org.lostnomore.backend.global.resolver;
+
+import jakarta.servlet.http.HttpServletRequest;
+import lombok.RequiredArgsConstructor;
+import org.lostnomore.backend.auth.provider.JwtTokenProvider;
+import org.lostnomore.backend.auth.util.BearerAuthorizationExtractor;
+import org.lostnomore.backend.global.LoginUser;
+import org.lostnomore.backend.global.dto.LoginUserDto;
+import org.springframework.core.MethodParameter;
+import org.springframework.stereotype.Component;
+import org.springframework.web.bind.support.WebDataBinderFactory;
+import org.springframework.web.context.request.NativeWebRequest;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.method.support.ModelAndViewContainer;
+
+@Component
+@RequiredArgsConstructor
+public class AccessTokenArgumentResolver implements HandlerMethodArgumentResolver {
+
+    private final JwtTokenProvider jwtTokenProvider;
+    private final BearerAuthorizationExtractor bearerAuthorizationExtractor;
+
+    @Override
+    public boolean supportsParameter(MethodParameter parameter) {
+        return parameter.hasParameterAnnotation(LoginUser.class);
+    }
+
+    @Override
+    public Object resolveArgument(MethodParameter parameter, ModelAndViewContainer mavContainer, NativeWebRequest webRequest, WebDataBinderFactory binderFactory) throws Exception {
+        HttpServletRequest request = webRequest.getNativeRequest(HttpServletRequest.class);
+        String accessToken = bearerAuthorizationExtractor.extractAccessToken(request.getHeader("Authorization"));
+        Long userId = jwtTokenProvider.getSubject(accessToken);
+
+        return new LoginUserDto(userId);
+    }
+}

--- a/src/test/java/org/lostnomore/backend/auth/controller/AuthControllerTest.java
+++ b/src/test/java/org/lostnomore/backend/auth/controller/AuthControllerTest.java
@@ -12,8 +12,10 @@ import jakarta.servlet.http.Cookie;
 import org.junit.jupiter.api.Test;
 import org.lostnomore.backend.auth.dto.UserTokenDto;
 import org.lostnomore.backend.auth.provider.CookieProvider;
+import org.lostnomore.backend.auth.provider.JwtTokenProvider;
 import org.lostnomore.backend.auth.provider.OAuthProvider;
 import org.lostnomore.backend.auth.service.AuthService;
+import org.lostnomore.backend.auth.util.BearerAuthorizationExtractor;
 import org.lostnomore.backend.common.ControllerTest;
 import org.lostnomore.backend.global.exception.BusinessException;
 import org.lostnomore.backend.global.exception.code.AuthErrorCode;
@@ -27,8 +29,11 @@ import org.springframework.test.context.bean.override.mockito.MockitoBean;
 @WebMvcTest(AuthController.class)
 class AuthControllerTest extends ControllerTest {
 
-    @Mock
+    @MockitoBean
     private OAuthProvider oAuthProvider;
+
+    @MockitoBean
+    private JwtTokenProvider jwtTokenProvider;
 
     @MockitoBean
     private AuthService authService;
@@ -36,8 +41,8 @@ class AuthControllerTest extends ControllerTest {
     @MockitoBean
     private CookieProvider cookieProvider;
 
-    @InjectMocks
-    private AuthController authController;
+    @MockitoBean
+    private BearerAuthorizationExtractor bearerAuthorizationExtractor;
 
     private final static String REFRESH_TOKEN = "refreshToken";
     private final static String ACCESS_TOKEN = "accessToken";

--- a/src/test/java/org/lostnomore/backend/auth/controller/AuthControllerTest.java
+++ b/src/test/java/org/lostnomore/backend/auth/controller/AuthControllerTest.java
@@ -12,16 +12,12 @@ import jakarta.servlet.http.Cookie;
 import org.junit.jupiter.api.Test;
 import org.lostnomore.backend.auth.dto.UserTokenDto;
 import org.lostnomore.backend.auth.provider.CookieProvider;
-import org.lostnomore.backend.auth.provider.JwtTokenProvider;
 import org.lostnomore.backend.auth.provider.OAuthProvider;
 import org.lostnomore.backend.auth.service.AuthService;
-import org.lostnomore.backend.auth.util.BearerAuthorizationExtractor;
 import org.lostnomore.backend.common.ControllerTest;
 import org.lostnomore.backend.global.exception.BusinessException;
 import org.lostnomore.backend.global.exception.code.AuthErrorCode;
 import org.lostnomore.backend.global.exception.code.BusinessErrorCode;
-import org.mockito.InjectMocks;
-import org.mockito.Mock;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.http.HttpHeaders;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
@@ -33,16 +29,10 @@ class AuthControllerTest extends ControllerTest {
     private OAuthProvider oAuthProvider;
 
     @MockitoBean
-    private JwtTokenProvider jwtTokenProvider;
-
-    @MockitoBean
     private AuthService authService;
 
     @MockitoBean
     private CookieProvider cookieProvider;
-
-    @MockitoBean
-    private BearerAuthorizationExtractor bearerAuthorizationExtractor;
 
     private final static String REFRESH_TOKEN = "refreshToken";
     private final static String ACCESS_TOKEN = "accessToken";

--- a/src/test/java/org/lostnomore/backend/auth/provider/JwtTokenProviderTest.java
+++ b/src/test/java/org/lostnomore/backend/auth/provider/JwtTokenProviderTest.java
@@ -52,10 +52,9 @@ class JwtTokenProviderTest {
         // given
         JwtTokenProvider tokenProvider = new JwtTokenProvider(JWT_SECRET_KEY, 0, 10000000);
         String expiredAccessToken = tokenProvider.createAccessToken(PAYLOAD);
-        String nonExpiredRefreshToken = tokenProvider.createRefreshToken(PAYLOAD);
 
         // when & then
-        assertThatThrownBy(() -> jwtTokenProvider.validateTokens(expiredAccessToken, nonExpiredRefreshToken))
+        assertThatThrownBy(() -> jwtTokenProvider.validateAccessToken(expiredAccessToken))
                 .isInstanceOf(ExpiredPeriodJwtException.class);
     }
 
@@ -63,11 +62,10 @@ class JwtTokenProviderTest {
     void 리프레시_토큰을_검증하여_만료된_경우_예외() {
         // given
         JwtTokenProvider tokenProvider = new JwtTokenProvider(JWT_SECRET_KEY, 10000000, 0);
-        String nonexpiredAccessToken = tokenProvider.createAccessToken(PAYLOAD);
         String expiredRefreshToken = tokenProvider.createRefreshToken(PAYLOAD);
 
         // when & then
-        assertThatThrownBy(() -> jwtTokenProvider.validateTokens(nonexpiredAccessToken, expiredRefreshToken))
+        assertThatThrownBy(() -> jwtTokenProvider.validateRefreshToken(expiredRefreshToken))
                 .isInstanceOf(ExpiredPeriodJwtException.class);
     }
 
@@ -75,10 +73,9 @@ class JwtTokenProviderTest {
     void 잘못된_토큰_양식일_경우_예외() {
         // given
         String wrongToken = "wrong-token";
-        String rigntToken = "right-token";
 
         // when & then
-        assertThatThrownBy(() -> jwtTokenProvider.validateTokens(wrongToken, rigntToken))
+        assertThatThrownBy(() -> jwtTokenProvider.validateAccessToken(wrongToken))
                 .isInstanceOf(InvalidJwtException.class);
     }
 }

--- a/src/test/java/org/lostnomore/backend/auth/service/AuthServiceTest.java
+++ b/src/test/java/org/lostnomore/backend/auth/service/AuthServiceTest.java
@@ -1,10 +1,10 @@
 package org.lostnomore.backend.auth.service;
 
-import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.anyLong;
 import static org.mockito.Mockito.anyString;
+import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
@@ -12,8 +12,10 @@ import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import java.util.Optional;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.lostnomore.backend.auth.domain.RefreshToken;
 import org.lostnomore.backend.auth.dto.UserTokenDto;
 import org.lostnomore.backend.auth.provider.JwtTokenProvider;
 import org.lostnomore.backend.auth.provider.OAuthProvider;
@@ -95,25 +97,24 @@ class AuthServiceTest extends ServiceTest {
     }
 
     @Test
-    void 토큰들이_만료되지_않으면_기존_토큰_반환() {
+    void 리프레시_토큰_저장소에_존재하지_않으면_오류() {
         // given
+        doNothing().when(jwtTokenProvider).validateRefreshToken(anyString());
         when(bearerAuthorizationExtractor.extractAccessToken(anyString())).thenReturn(accessToken);
-        when(jwtTokenProvider.isValidRefreshAndInvalidAccess(refreshToken, accessToken)).thenReturn(false);
-        when(jwtTokenProvider.isValidRefreshAndValidAccess(refreshToken, accessToken)).thenReturn(true);
-        // when
-        UserTokenDto reissue = authService.reissue(refreshToken, anyString());
+        when(refreshTokenRepository.findById(refreshToken)).thenReturn(Optional.empty());
 
-        // then
-        assertThat(reissue.getAccessToken()).isEqualTo(accessToken);
-        assertThat(reissue.getRefreshToken()).isNull();
+        // when & then
+        assertThatThrownBy(() -> authService.reissue(refreshToken, anyString()))
+                .isInstanceOf(BusinessException.class);
     }
 
     @Test
-    void 토큰들이_모두_만료되면_오류() {
+    void 만료된_엑세스_토큰의_userId와_리프레시_토큰_저장소의_토큰의_userId가_다를_시_오류() {
         // given
+        doNothing().when(jwtTokenProvider).validateRefreshToken(anyString());
         when(bearerAuthorizationExtractor.extractAccessToken(anyString())).thenReturn(accessToken);
-        when(jwtTokenProvider.isValidRefreshAndInvalidAccess(refreshToken, accessToken)).thenReturn(false);
-        when(jwtTokenProvider.isValidRefreshAndValidAccess(refreshToken, accessToken)).thenReturn(false);
+        when(refreshTokenRepository.findById(refreshToken)).thenReturn(Optional.of(new RefreshToken(refreshToken, 1L)));
+        when(jwtTokenProvider.getExpiredSubject(accessToken)).thenReturn(2L);
 
         // when & then
         assertThatThrownBy(() -> authService.reissue(refreshToken, anyString()))

--- a/src/test/java/org/lostnomore/backend/auth/service/AuthServiceTest.java
+++ b/src/test/java/org/lostnomore/backend/auth/service/AuthServiceTest.java
@@ -101,7 +101,7 @@ class AuthServiceTest extends ServiceTest {
         when(jwtTokenProvider.isValidRefreshAndInvalidAccess(refreshToken, accessToken)).thenReturn(false);
         when(jwtTokenProvider.isValidRefreshAndValidAccess(refreshToken, accessToken)).thenReturn(true);
         // when
-        UserTokenDto reissue = authService.reissue(refreshToken, accessToken);
+        UserTokenDto reissue = authService.reissue(refreshToken, anyString());
 
         // then
         assertThat(reissue.getAccessToken()).isEqualTo(accessToken);
@@ -116,7 +116,7 @@ class AuthServiceTest extends ServiceTest {
         when(jwtTokenProvider.isValidRefreshAndValidAccess(refreshToken, accessToken)).thenReturn(false);
 
         // when & then
-        assertThatThrownBy(() -> authService.reissue(refreshToken, accessToken))
+        assertThatThrownBy(() -> authService.reissue(refreshToken, anyString()))
                 .isInstanceOf(BusinessException.class);
     }
 }

--- a/src/test/java/org/lostnomore/backend/common/ControllerTest.java
+++ b/src/test/java/org/lostnomore/backend/common/ControllerTest.java
@@ -1,9 +1,13 @@
 package org.lostnomore.backend.common;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import org.lostnomore.backend.auth.provider.JwtTokenProvider;
+import org.lostnomore.backend.auth.util.BearerAuthorizationExtractor;
+import org.lostnomore.backend.global.resolver.AccessTokenArgumentResolver;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
 
 @WebMvcTest
@@ -16,4 +20,12 @@ public abstract class ControllerTest {
     @Autowired
     protected ObjectMapper objectMapper;
 
+    @MockitoBean
+    private JwtTokenProvider jwtTokenProvider;
+
+    @MockitoBean
+    protected BearerAuthorizationExtractor bearerAuthorizationExtractor;
+
+    @MockitoBean
+    protected AccessTokenArgumentResolver accessTokenArgumentResolver;
 }


### PR DESCRIPTION
## Related issue 🛠
- closed #26 

## Work Description ✏️
- jwt를 검증하는 interceptor 구현
- jwt의 userId 추출 후 객체를 반환하는 argumentResolver 구현

## Uncompleted Tasks 😅
- [ ] N/A

## To Reviewers 📢
- 인증/인가가 필요없는 엔드포인트는 WebConfig 클래스에서 추가하시면됩니다. 추가로 @LoginUserDto에 사용자들을 구분하는 값(User엔티티의 id값)이 담겨져있어 이용하시면됩니다. 