### PR TITLE
[FEAT] 분실물 알림 리스트, 최근 분실물 조회 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -56,7 +56,7 @@ dependencies {
 
 	//elastic
 	implementation 'org.springframework.boot:spring-boot-starter-data-elasticsearch'
-	implementation 'co.elastic.clients:elasticsearch-java:8.10.2'
+	implementation 'co.elastic.clients:elasticsearch-java:8.15.5'
 }
 
 tasks.named('test') {

--- a/src/main/java/org/lostnomore/backend/item/controller/LostItemController.java
+++ b/src/main/java/org/lostnomore/backend/item/controller/LostItemController.java
@@ -55,7 +55,7 @@ public class LostItemController {
             @RequestParam Double bottom_right_lat,
             @RequestParam Double bottom_right_lon,
             @RequestParam(required = false) String keyword,
-            @RequestParam(required = false) Integer category_id,
+            @RequestParam(required = false) Long category_id,
             @RequestParam(required = false) String region
     ) {
         return ResponseEntity.ok(ResponseDto.success(lostItemService.searchLostItems(

--- a/src/main/java/org/lostnomore/backend/item/controller/LostItemController.java
+++ b/src/main/java/org/lostnomore/backend/item/controller/LostItemController.java
@@ -5,7 +5,6 @@ import org.lostnomore.backend.global.dto.ResponseDto;
 import org.lostnomore.backend.item.dto.request.LostItemIdsDto;
 import org.lostnomore.backend.item.dto.response.ItemsCountDto;
 import org.lostnomore.backend.item.dto.response.LostItemsListDto;
-import org.lostnomore.backend.item.dto.response.RecentItemsDto;
 import org.lostnomore.backend.item.dto.request.LostItemCreateDto;
 import org.lostnomore.backend.item.dto.response.LostItemsSearchDto;
 import org.lostnomore.backend.item.service.LostItemService;
@@ -29,13 +28,6 @@ public class LostItemController {
     @GetMapping("items/count")
     public ResponseEntity<ResponseDto<ItemsCountDto>> getItemsCount () {
         return ResponseEntity.status(HttpStatus.OK).body(ResponseDto.success(lostItemService.getItemsCount()));
-    }
-
-    @GetMapping("items/recent")
-    public ResponseEntity<ResponseDto<RecentItemsDto>> getRecentItems (
-            final Long userId
-    ) {
-        return ResponseEntity.status(HttpStatus.OK).body(ResponseDto.success(lostItemService.getRecentItems(userId)));
     }
 
     @PostMapping("/items")

--- a/src/main/java/org/lostnomore/backend/item/elastic/LostItemSearchService.java
+++ b/src/main/java/org/lostnomore/backend/item/elastic/LostItemSearchService.java
@@ -31,7 +31,7 @@ public class LostItemSearchService {
             Double bottomRightLat,
             Double bottomRightLon,
             String keyword,
-            Integer categoryId,
+            Long categoryId,
             String region
     ) {
 
@@ -117,5 +117,12 @@ public class LostItemSearchService {
                 .build();
 
         return elasticsearchOperations.search(searchQuery, LostItemDocument.class);
+    }
+
+    @Transactional(readOnly = true)
+    public SearchHits<LostItemDocument> searchLostItemsForSubscription(
+            LocalDate dateStart, LocalDate dateEnd,
+            String keyword, Long categoryId, String region) {
+        return searchLostItems(dateStart, dateEnd, null, null, null, null, keyword, categoryId, region);
     }
 }

--- a/src/main/java/org/lostnomore/backend/item/elastic/LostItemSearchService.java
+++ b/src/main/java/org/lostnomore/backend/item/elastic/LostItemSearchService.java
@@ -2,6 +2,8 @@ package org.lostnomore.backend.item.elastic;
 
 import co.elastic.clients.elasticsearch._types.GeoBounds;
 import co.elastic.clients.elasticsearch._types.GeoLocation;
+import co.elastic.clients.elasticsearch._types.SortOptions;
+import co.elastic.clients.elasticsearch._types.SortOrder;
 import co.elastic.clients.elasticsearch._types.query_dsl.*;
 import co.elastic.clients.json.JsonData;
 
@@ -112,8 +114,15 @@ public class LostItemSearchService {
 
         Query boolQuery = boolQueryBuilder.build()._toQuery();
 
+        List<SortOptions> sortOptions = List.of(
+                SortOptions.of(s -> s.field(f -> f.field("date").order(SortOrder.Desc))),
+                SortOptions.of(s -> s.field(f -> f.field("id").order(SortOrder.Desc)))
+        );
+
         NativeQuery searchQuery = NativeQuery.builder()
                 .withQuery(boolQuery)
+                .withSort(sortOptions)
+                .withPageable(size != null ? PageRequest.of(0, size) : Pageable.unpaged())
                 .build();
 
         return elasticsearchOperations.search(searchQuery, LostItemDocument.class);

--- a/src/main/java/org/lostnomore/backend/item/elastic/LostItemSearchService.java
+++ b/src/main/java/org/lostnomore/backend/item/elastic/LostItemSearchService.java
@@ -85,20 +85,22 @@ public class LostItemSearchService {
         }
 
         // 위치 필터
-        GeoBoundingBoxQuery geoQuery = GeoBoundingBoxQuery.of(g -> g
-                .field("location")
-                .boundingBox(
-                        GeoBounds.of(outer -> outer.tlbr(b -> b
-                                .topLeft(GeoLocation.of(loc ->
-                                        loc.text(topLeftLat + "," + topLeftLon)
-                                ))
-                                .bottomRight(GeoLocation.of(loc ->
-                                        loc.text(bottomRightLat + "," + bottomRightLon)
-                                ))
-                        ))
-                )
-        );
-        mustQueries.add(geoQuery._toQuery());
+        if (topLeftLat != null && topLeftLon != null && bottomRightLat != null && bottomRightLon != null) {
+            GeoBoundingBoxQuery geoQuery = GeoBoundingBoxQuery.of(g -> g
+                    .field("location")
+                    .boundingBox(
+                            GeoBounds.of(outer -> outer.tlbr(b -> b
+                                    .topLeft(GeoLocation.of(loc ->
+                                            loc.text(topLeftLat + "," + topLeftLon)
+                                    ))
+                                    .bottomRight(GeoLocation.of(loc ->
+                                            loc.text(bottomRightLat + "," + bottomRightLon)
+                                    ))
+                            ))
+                    )
+            );
+            mustQueries.add(geoQuery._toQuery());
+        }
 
         BoolQuery.Builder boolQueryBuilder = new BoolQuery.Builder()
                 .must(mustQueries); // 필수 조건 추가

--- a/src/main/java/org/lostnomore/backend/item/elastic/LostItemSearchService.java
+++ b/src/main/java/org/lostnomore/backend/item/elastic/LostItemSearchService.java
@@ -5,9 +5,10 @@ import co.elastic.clients.elasticsearch._types.GeoLocation;
 import co.elastic.clients.elasticsearch._types.SortOptions;
 import co.elastic.clients.elasticsearch._types.SortOrder;
 import co.elastic.clients.elasticsearch._types.query_dsl.*;
-import co.elastic.clients.json.JsonData;
 
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.elasticsearch.client.elc.NativeQuery;
 import org.springframework.data.elasticsearch.core.ElasticsearchOperations;
 import org.springframework.data.elasticsearch.core.SearchHits;
@@ -34,18 +35,21 @@ public class LostItemSearchService {
             Double bottomRightLon,
             String keyword,
             Long categoryId,
-            String region
+            String region,
+            Integer size
     ) {
 
         List<Query> mustQueries = new ArrayList<>();
         List<Query> shouldQueries = new ArrayList<>();
 
         // 날짜 범위
-        RangeQuery dateRangeQuery = RangeQuery.of(r -> r
-                .field("date")
-                .gte(JsonData.of(dateStart.toString()))
-                .lte(JsonData.of(dateEnd.toString()))
-        );
+        RangeQuery dateRangeQuery = new RangeQuery.Builder()
+                .date(d -> d
+                        .field("date")
+                        .gte(dateStart.toString())
+                        .lte(dateEnd.toString())
+                )
+                .build();
         mustQueries.add(dateRangeQuery._toQuery());
 
         // 키워드 검색
@@ -131,7 +135,7 @@ public class LostItemSearchService {
     @Transactional(readOnly = true)
     public SearchHits<LostItemDocument> searchLostItemsForSubscription(
             LocalDate dateStart, LocalDate dateEnd,
-            String keyword, Long categoryId, String region) {
-        return searchLostItems(dateStart, dateEnd, null, null, null, null, keyword, categoryId, region);
+            String keyword, Long categoryId, String region, Integer size) {
+        return searchLostItems(dateStart, dateEnd, null, null, null, null, keyword, categoryId, region, size);
     }
 }

--- a/src/main/java/org/lostnomore/backend/item/manager/LostItemRetriever.java
+++ b/src/main/java/org/lostnomore/backend/item/manager/LostItemRetriever.java
@@ -38,6 +38,8 @@ public class LostItemRetriever {
     ) {
         return lostItemRepository.findByIdInWithCursorPagination(ids, cursorDate, cursorId, size);
 
+    }
+
     public LostItem findById(final Long lostItemId) {
         return lostItemRepository.findById(lostItemId)
                 .orElseThrow(() -> new BusinessException(ItemErrorCode.ITEM_NOT_FOUND));

--- a/src/main/java/org/lostnomore/backend/item/manager/LostItemRetriever.java
+++ b/src/main/java/org/lostnomore/backend/item/manager/LostItemRetriever.java
@@ -9,7 +9,9 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Component;
 
+import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.util.ArrayList;
 import java.util.List;
 
 @Component
@@ -31,5 +33,14 @@ public class LostItemRetriever {
 
     public List<LostItem> findByIdIn(List<Long> ids) {
         return lostItemRepository.findByIdIn(ids);
+    }
+
+    public List<LostItem> findByIdInWithCursorPagination(
+            final ArrayList<Long> ids,
+            final LocalDate cursorDate,
+            final Long cursorId,
+            final int size
+    ) {
+        return lostItemRepository.findByIdInWithCursorPagination(ids, cursorDate, cursorId, size);
     }
 }

--- a/src/main/java/org/lostnomore/backend/item/manager/LostItemRetriever.java
+++ b/src/main/java/org/lostnomore/backend/item/manager/LostItemRetriever.java
@@ -24,13 +24,6 @@ public class LostItemRetriever {
         return lostItemRepository.findItemCountByCreatedAtAfter(today);
     }
 
-    public Page<LostItem> findRecentItemsByUserId(
-            final Long userId,
-            final Pageable pageable
-    ) {
-        return lostItemRepository.findRecentItemsByUserId(userId, pageable);
-    }
-
     public List<LostItem> findByIdIn(List<Long> ids) {
         return lostItemRepository.findByIdIn(ids);
     }

--- a/src/main/java/org/lostnomore/backend/item/manager/LostItemRetriever.java
+++ b/src/main/java/org/lostnomore/backend/item/manager/LostItemRetriever.java
@@ -31,7 +31,7 @@ public class LostItemRetriever {
     }
 
     public List<LostItem> findByIdInWithCursorPagination(
-            final ArrayList<Long> ids,
+            final List<Long> ids,
             final LocalDate cursorDate,
             final Long cursorId,
             final int size

--- a/src/main/java/org/lostnomore/backend/item/repository/LostItemRepository.java
+++ b/src/main/java/org/lostnomore/backend/item/repository/LostItemRepository.java
@@ -9,7 +9,9 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
+import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.util.ArrayList;
 import java.util.List;
 
 public interface LostItemRepository extends JpaRepository<LostItem, Long> {
@@ -40,4 +42,15 @@ public interface LostItemRepository extends JpaRepository<LostItem, Long> {
        WHERE l.id IN :ids
        """)
     List<LostItem> findByIdIn(List<Long> ids);
+
+    @Query("""
+       SELECT l FROM LostItem l
+       JOIN FETCH l.location
+       JOIN FETCH l.category
+       WHERE l.id IN :ids
+       AND (:cursorDate IS NULL OR (l.date < :cursorDate OR (l.date = :cursorDate AND l.id < :cursorId)))\s
+       ORDER BY l.date DESC, l.id DESC
+       LIMIT :size
+       """)
+    List<LostItem> findByIdInWithCursorPagination(ArrayList<Long> ids, LocalDate cursorDate, Long cursorId, int size);
 }

--- a/src/main/java/org/lostnomore/backend/item/repository/LostItemRepository.java
+++ b/src/main/java/org/lostnomore/backend/item/repository/LostItemRepository.java
@@ -43,7 +43,7 @@ public interface LostItemRepository extends JpaRepository<LostItem, Long> {
        ORDER BY l.date DESC, l.id DESC
        LIMIT :size
        """)
-    List<LostItem> findByIdInWithCursorPagination(ArrayList<Long> ids, LocalDate cursorDate, Long cursorId, int size);
+    List<LostItem> findByIdInWithCursorPagination(List<Long> ids, LocalDate cursorDate, Long cursorId, int size);
 
     @Query("""
       SELECT l FROM LostItem l

--- a/src/main/java/org/lostnomore/backend/item/repository/LostItemRepository.java
+++ b/src/main/java/org/lostnomore/backend/item/repository/LostItemRepository.java
@@ -27,19 +27,9 @@ public interface LostItemRepository extends JpaRepository<LostItem, Long> {
     @Query("""
        SELECT l FROM LostItem l
        JOIN FETCH l.location
-       WHERE l.category IN (
-           SELECT s.category FROM Subscribe s WHERE s.user.id = :userId
-       )
-       ORDER BY l.createdDate DESC
-       """)
-    Page<LostItem> findRecentItemsByUserId(Long userId, Pageable pageable);
-
-
-    @Query("""
-       SELECT l FROM LostItem l
-       JOIN FETCH l.location
        JOIN FETCH l.category
        WHERE l.id IN :ids
+       ORDER BY l.date DESC, l.id DESC
        """)
     List<LostItem> findByIdIn(List<Long> ids);
 

--- a/src/main/java/org/lostnomore/backend/item/service/LostItemService.java
+++ b/src/main/java/org/lostnomore/backend/item/service/LostItemService.java
@@ -5,7 +5,6 @@ import org.lostnomore.backend.item.domain.Category;
 import org.lostnomore.backend.item.domain.Location;
 import org.lostnomore.backend.item.domain.LostItem;
 import org.lostnomore.backend.item.dto.request.LostItemCreateDto;
-import org.lostnomore.backend.item.dto.request.LostItemIdsDto;
 import org.lostnomore.backend.item.dto.response.*;
 import org.lostnomore.backend.item.elastic.LostItemDocument;
 import org.lostnomore.backend.item.elastic.LostItemSearchRepository;

--- a/src/main/java/org/lostnomore/backend/item/service/LostItemService.java
+++ b/src/main/java/org/lostnomore/backend/item/service/LostItemService.java
@@ -13,9 +13,6 @@ import org.lostnomore.backend.item.elastic.LostItemSearchService;
 import org.lostnomore.backend.item.manager.*;
 import jakarta.persistence.Tuple;
 import org.lostnomore.backend.item.dto.response.ItemsCountDto;
-import org.lostnomore.backend.item.dto.response.RecentItemsDto;
-import org.springframework.data.domain.PageRequest;
-import org.springframework.data.domain.Pageable;
 import org.springframework.data.elasticsearch.core.SearchHits;
 import org.springframework.data.elasticsearch.core.geo.GeoPoint;
 import org.springframework.stereotype.Service;
@@ -44,14 +41,6 @@ public class LostItemService {
         Long totalCount = stats.get(1, Long.class);
 
         return ItemsCountDto.of(todayCount.intValue(), totalCount.intValue());
-    }
-
-    @Transactional(readOnly = true)
-    public RecentItemsDto getRecentItems(final Long userId) {
-        Pageable pageable = PageRequest.of(0, 9);
-        List<LostItem> recentItems = lostItemRetriever.findRecentItemsByUserId(userId, pageable).getContent();
-
-        return RecentItemsDto.from(recentItems);
     }
 
     @Transactional
@@ -107,7 +96,7 @@ public class LostItemService {
                 dateStart, dateEnd,
                 topLeftLat, topLeftLon,
                 bottomRightLat, bottomRightLon,
-                keyword, categoryId, region
+                keyword, categoryId, region, null
         );
 
         return LostItemsSearchDto.from(lostItems);

--- a/src/main/java/org/lostnomore/backend/item/service/LostItemService.java
+++ b/src/main/java/org/lostnomore/backend/item/service/LostItemService.java
@@ -1,12 +1,10 @@
 package org.lostnomore.backend.item.service;
 
 import lombok.RequiredArgsConstructor;
-import org.lostnomore.backend.global.dto.ResponseDto;
 import org.lostnomore.backend.item.domain.Category;
 import org.lostnomore.backend.item.domain.Location;
 import org.lostnomore.backend.item.domain.LostItem;
 import org.lostnomore.backend.item.dto.request.LostItemCreateDto;
-import org.lostnomore.backend.item.dto.request.LostItemIdsDto;
 import org.lostnomore.backend.item.dto.response.LostItemsListDto;
 import org.lostnomore.backend.item.dto.response.LostItemsSearchDto;
 import org.lostnomore.backend.item.elastic.LostItemDocument;
@@ -20,7 +18,6 @@ import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.elasticsearch.core.SearchHits;
 import org.springframework.data.elasticsearch.core.geo.GeoPoint;
-import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -103,7 +100,7 @@ public class LostItemService {
             LocalDate dateStart, LocalDate dateEnd,
             Double topLeftLat, Double topLeftLon,
             Double bottomRightLat, Double bottomRightLon,
-            String keyword, Integer categoryId, String region
+            String keyword, Long categoryId, String region
     ) {
 
         SearchHits<LostItemDocument> lostItems = lostItemSearchService.searchLostItems(

--- a/src/main/java/org/lostnomore/backend/subscribe/controller/SubscribeController.java
+++ b/src/main/java/org/lostnomore/backend/subscribe/controller/SubscribeController.java
@@ -1,7 +1,31 @@
 package org.lostnomore.backend.subscribe.controller;
 
+import lombok.RequiredArgsConstructor;
+import org.lostnomore.backend.global.dto.ResponseDto;
+import org.lostnomore.backend.item.dto.request.LostItemIdsDto;
+import org.lostnomore.backend.item.dto.response.LostItemsListDto;
+import org.lostnomore.backend.subscribe.service.SubscribeService;
+import org.springframework.format.annotation.DateTimeFormat;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
+import java.time.LocalDate;
+
 @RestController
+@RequiredArgsConstructor
 public class SubscribeController {
+
+    private final SubscribeService subscribeService;
+
+    @GetMapping("/subscribe/list")
+    public ResponseEntity<ResponseDto<LostItemsListDto>> getSubscribeList(
+            final Long userId,
+            @RequestParam @DateTimeFormat(pattern = "yyyy-MM-dd") LocalDate date_start,
+            @RequestParam @DateTimeFormat(pattern = "yyyy-MM-dd") LocalDate date_end,
+            @RequestParam(required = false) String keyword
+    ) {
+        return ResponseEntity.ok().body(ResponseDto.success(subscribeService.getSubscribeList(userId, date_start, date_end, keyword)));
+    }
 }

--- a/src/main/java/org/lostnomore/backend/subscribe/controller/SubscribeController.java
+++ b/src/main/java/org/lostnomore/backend/subscribe/controller/SubscribeController.java
@@ -2,11 +2,14 @@ package org.lostnomore.backend.subscribe.controller;
 
 import lombok.RequiredArgsConstructor;
 import org.lostnomore.backend.global.dto.ResponseDto;
+import org.lostnomore.backend.subscribe.dto.response.RecentItemsDto;
 import org.lostnomore.backend.subscribe.dto.response.SubscribeListDto;
 import org.lostnomore.backend.subscribe.service.SubscribeService;
 import org.springframework.format.annotation.DateTimeFormat;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -18,9 +21,16 @@ public class SubscribeController {
 
     private final SubscribeService subscribeService;
 
-    @GetMapping("/subscribe/list")
+    @GetMapping("items/recent/{userId}")
+    public ResponseEntity<ResponseDto<RecentItemsDto>> getRecentItems (
+            @PathVariable final Long userId
+    ) {
+        return ResponseEntity.status(HttpStatus.OK).body(ResponseDto.success(subscribeService.getRecentItems(userId)));
+    }
+
+    @GetMapping("/subscribe/list/{userId}")
     public ResponseEntity<ResponseDto<SubscribeListDto>> getSubscribeList(
-            final Long userId,
+            @PathVariable final Long userId,
             @RequestParam @DateTimeFormat(pattern = "yyyy-MM-dd") LocalDate date_start,
             @RequestParam @DateTimeFormat(pattern = "yyyy-MM-dd") LocalDate date_end,
             @RequestParam(required = false) String keyword,

--- a/src/main/java/org/lostnomore/backend/subscribe/controller/SubscribeController.java
+++ b/src/main/java/org/lostnomore/backend/subscribe/controller/SubscribeController.java
@@ -2,8 +2,7 @@ package org.lostnomore.backend.subscribe.controller;
 
 import lombok.RequiredArgsConstructor;
 import org.lostnomore.backend.global.dto.ResponseDto;
-import org.lostnomore.backend.item.dto.request.LostItemIdsDto;
-import org.lostnomore.backend.item.dto.response.LostItemsListDto;
+import org.lostnomore.backend.subscribe.dto.response.SubscribeListDto;
 import org.lostnomore.backend.subscribe.service.SubscribeService;
 import org.springframework.format.annotation.DateTimeFormat;
 import org.springframework.http.ResponseEntity;
@@ -20,12 +19,18 @@ public class SubscribeController {
     private final SubscribeService subscribeService;
 
     @GetMapping("/subscribe/list")
-    public ResponseEntity<ResponseDto<LostItemsListDto>> getSubscribeList(
+    public ResponseEntity<ResponseDto<SubscribeListDto>> getSubscribeList(
             final Long userId,
             @RequestParam @DateTimeFormat(pattern = "yyyy-MM-dd") LocalDate date_start,
             @RequestParam @DateTimeFormat(pattern = "yyyy-MM-dd") LocalDate date_end,
-            @RequestParam(required = false) String keyword
+            @RequestParam(required = false) String keyword,
+            @RequestParam(required = false) @DateTimeFormat(pattern = "yyyy-MM-dd") LocalDate cursorDate,
+            @RequestParam(required = false) Long cursorId,
+            @RequestParam(defaultValue = "8") int size
     ) {
-        return ResponseEntity.ok().body(ResponseDto.success(subscribeService.getSubscribeList(userId, date_start, date_end, keyword)));
+        return ResponseEntity.ok().body(ResponseDto.success(subscribeService.getSubscribeList(
+                userId, date_start, date_end, keyword,
+                cursorDate, cursorId, size
+        )));
     }
 }

--- a/src/main/java/org/lostnomore/backend/subscribe/controller/SubscribeController.java
+++ b/src/main/java/org/lostnomore/backend/subscribe/controller/SubscribeController.java
@@ -9,7 +9,6 @@ import org.springframework.format.annotation.DateTimeFormat;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -21,16 +20,16 @@ public class SubscribeController {
 
     private final SubscribeService subscribeService;
 
-    @GetMapping("items/recent/{userId}")
+    @GetMapping("items/recent")
     public ResponseEntity<ResponseDto<RecentItemsDto>> getRecentItems (
-            @PathVariable final Long userId
+            final Long userId
     ) {
         return ResponseEntity.status(HttpStatus.OK).body(ResponseDto.success(subscribeService.getRecentItems(userId)));
     }
 
-    @GetMapping("/subscribe/list/{userId}")
+    @GetMapping("/subscribe/list")
     public ResponseEntity<ResponseDto<SubscribeListDto>> getSubscribeList(
-            @PathVariable final Long userId,
+            final Long userId,
             @RequestParam @DateTimeFormat(pattern = "yyyy-MM-dd") LocalDate date_start,
             @RequestParam @DateTimeFormat(pattern = "yyyy-MM-dd") LocalDate date_end,
             @RequestParam(required = false) String keyword,

--- a/src/main/java/org/lostnomore/backend/subscribe/domain/Subscribe.java
+++ b/src/main/java/org/lostnomore/backend/subscribe/domain/Subscribe.java
@@ -39,10 +39,14 @@ public class Subscribe extends BaseEntity {
     @Column(name = "keyword", nullable = false)
     private String keyword;
 
+    @Column(name = "region", nullable = false)
+    private String region;
+
     @Builder
-    public Subscribe(User user, Category category, String keyword) {
+    public Subscribe(User user, Category category, String keyword, String region) {
         this.user = user;
         this.category = category;
         this.keyword = keyword;
+        this.region = region;
     }
 }

--- a/src/main/java/org/lostnomore/backend/subscribe/dto/response/RecentItemsDto.java
+++ b/src/main/java/org/lostnomore/backend/subscribe/dto/response/RecentItemsDto.java
@@ -1,4 +1,4 @@
-package org.lostnomore.backend.item.dto.response;
+package org.lostnomore.backend.subscribe.dto.response;
 
 import org.lostnomore.backend.item.domain.LostItem;
 

--- a/src/main/java/org/lostnomore/backend/subscribe/dto/response/SubscribeListDto.java
+++ b/src/main/java/org/lostnomore/backend/subscribe/dto/response/SubscribeListDto.java
@@ -1,0 +1,25 @@
+package org.lostnomore.backend.subscribe.dto.response;
+
+import org.lostnomore.backend.item.domain.LostItem;
+import org.lostnomore.backend.item.dto.response.LostItemListDto;
+
+import java.time.LocalDate;
+import java.util.List;
+
+public record SubscribeListDto(
+        int totalCount,
+        List<LostItemListDto> lostItems,
+        LocalDate nextCursorDate,
+        Long nextCursorId
+) {
+    public static SubscribeListDto from(List<LostItem> lostItems, LocalDate nextCursorDate, Long nextCursorId) {
+        return new SubscribeListDto(
+                lostItems.size(),
+                lostItems.stream()
+                        .map(LostItemListDto::from)
+                        .toList(),
+                nextCursorDate,
+                nextCursorId
+        );
+    }
+}

--- a/src/main/java/org/lostnomore/backend/subscribe/manager/SubscribeRetriever.java
+++ b/src/main/java/org/lostnomore/backend/subscribe/manager/SubscribeRetriever.java
@@ -1,0 +1,19 @@
+package org.lostnomore.backend.subscribe.manager;
+
+import lombok.RequiredArgsConstructor;
+import org.lostnomore.backend.subscribe.domain.Subscribe;
+import org.lostnomore.backend.subscribe.repository.SubscribeRepository;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+
+@Component
+@RequiredArgsConstructor
+public class SubscribeRetriever {
+
+    private final SubscribeRepository subscribeRepository;
+
+    public List<Subscribe> findByUserId(final Long userId) {
+        return subscribeRepository.findByUserId(userId);
+    }
+}

--- a/src/main/java/org/lostnomore/backend/subscribe/repository/SubscribeRepository.java
+++ b/src/main/java/org/lostnomore/backend/subscribe/repository/SubscribeRepository.java
@@ -4,6 +4,9 @@ import org.lostnomore.backend.subscribe.domain.Subscribe;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.util.List;
+
 public interface SubscribeRepository extends JpaRepository<Subscribe, Long> {
 
+    List<Subscribe> findByUserId(Long userId);
 }

--- a/src/main/java/org/lostnomore/backend/subscribe/service/SubscribeService.java
+++ b/src/main/java/org/lostnomore/backend/subscribe/service/SubscribeService.java
@@ -2,11 +2,11 @@ package org.lostnomore.backend.subscribe.service;
 
 import lombok.RequiredArgsConstructor;
 import org.lostnomore.backend.item.domain.LostItem;
-import org.lostnomore.backend.item.dto.response.LostItemsListDto;
 import org.lostnomore.backend.item.elastic.LostItemDocument;
 import org.lostnomore.backend.item.elastic.LostItemSearchService;
 import org.lostnomore.backend.item.manager.LostItemRetriever;
 import org.lostnomore.backend.subscribe.domain.Subscribe;
+import org.lostnomore.backend.subscribe.dto.response.SubscribeListDto;
 import org.lostnomore.backend.subscribe.manager.SubscribeRetriever;
 import org.springframework.data.elasticsearch.core.SearchHits;
 import org.springframework.stereotype.Service;
@@ -25,10 +25,13 @@ public class SubscribeService {
     private final LostItemRetriever lostItemRetriever;
 
     @Transactional(readOnly = true)
-    public LostItemsListDto getSubscribeList(
+    public SubscribeListDto getSubscribeList(
             final Long userId,
             final LocalDate dateStart, final LocalDate dateEnd,
-            final String keyword
+            final String keyword,
+            final LocalDate cursorDate,
+            final Long cursorId,
+            final int size
     ) {
         List<Subscribe> subscribes = subscribeRetriever.findByUserId(userId);
 
@@ -57,11 +60,19 @@ public class SubscribeService {
         }
 
         if (lostItemIds.isEmpty()) {
-            return new LostItemsListDto(0, Collections.emptyList());
+            return new SubscribeListDto(0, Collections.emptyList(), null, null);
         }
 
-        List<LostItem> finalLostItems = lostItemRetriever.findByIdIn(new ArrayList<>(lostItemIds));
+        List<LostItem> finalLostItems = lostItemRetriever.findByIdInWithCursorPagination(
+                new ArrayList<>(lostItemIds),
+                cursorDate,
+                cursorId,
+                size
+        );
 
-        return LostItemsListDto.from(finalLostItems);
+        LocalDate nextCursorDate = finalLostItems.isEmpty() ? null : finalLostItems.get(finalLostItems.size() - 1).getDate();
+        Long nextCursorId = finalLostItems.isEmpty() ? null : finalLostItems.get(finalLostItems.size() - 1).getId();
+
+        return SubscribeListDto.from(finalLostItems, nextCursorDate, nextCursorId);
     }
 }

--- a/src/main/java/org/lostnomore/backend/subscribe/service/SubscribeService.java
+++ b/src/main/java/org/lostnomore/backend/subscribe/service/SubscribeService.java
@@ -2,10 +2,12 @@ package org.lostnomore.backend.subscribe.service;
 
 import lombok.RequiredArgsConstructor;
 import org.lostnomore.backend.item.domain.LostItem;
+import org.lostnomore.backend.item.dto.response.LostItemListDto;
 import org.lostnomore.backend.item.elastic.LostItemDocument;
 import org.lostnomore.backend.item.elastic.LostItemSearchService;
 import org.lostnomore.backend.item.manager.LostItemRetriever;
 import org.lostnomore.backend.subscribe.domain.Subscribe;
+import org.lostnomore.backend.subscribe.dto.response.RecentItemsDto;
 import org.lostnomore.backend.subscribe.dto.response.SubscribeListDto;
 import org.lostnomore.backend.subscribe.manager.SubscribeRetriever;
 import org.springframework.data.elasticsearch.core.SearchHits;
@@ -23,6 +25,38 @@ public class SubscribeService {
     private final SubscribeRetriever subscribeRetriever;
     private final LostItemSearchService lostItemSearchService;
     private final LostItemRetriever lostItemRetriever;
+
+    @Transactional(readOnly = true)
+    public RecentItemsDto getRecentItems(final Long userId) {
+        LocalDate dateEnd = LocalDate.now().minusDays(1);
+        LocalDate dateStart = dateEnd.minusDays(7);
+
+        List<Subscribe> subscribes = subscribeRetriever.findByUserId(userId);
+        Set<Long> lostItemIds = new HashSet<>();
+
+        for (Subscribe subscribe : subscribes) {
+            SearchHits<LostItemDocument> searchHits = lostItemSearchService.searchLostItemsForSubscription(
+                    dateStart, dateEnd,
+                    subscribe.getKeyword(),
+                    subscribe.getCategory().getId(),
+                    subscribe.getRegion(),
+                    9
+            );
+
+            lostItemIds.addAll(
+                    searchHits.getSearchHits()
+                            .stream()
+                            .map(hit -> hit.getContent().getId())
+                            .collect(Collectors.toSet())
+            );
+        }
+
+        if (lostItemIds.isEmpty()) {
+            return new RecentItemsDto(Collections.emptyList());
+        }
+
+        return RecentItemsDto.from(lostItemRetriever.findByIdIn(new ArrayList<>(lostItemIds)));
+    }
 
     @Transactional(readOnly = true)
     public SubscribeListDto getSubscribeList(
@@ -48,7 +82,8 @@ public class SubscribeService {
                     dateStart, dateEnd,
                     subscribe.getKeyword(),
                     subscribe.getCategory().getId(),
-                    subscribe.getRegion()
+                    subscribe.getRegion(),
+                    null
             );
 
             lostItemIds.addAll(

--- a/src/main/java/org/lostnomore/backend/subscribe/service/SubscribeService.java
+++ b/src/main/java/org/lostnomore/backend/subscribe/service/SubscribeService.java
@@ -1,7 +1,67 @@
 package org.lostnomore.backend.subscribe.service;
 
+import lombok.RequiredArgsConstructor;
+import org.lostnomore.backend.item.domain.LostItem;
+import org.lostnomore.backend.item.dto.response.LostItemsListDto;
+import org.lostnomore.backend.item.elastic.LostItemDocument;
+import org.lostnomore.backend.item.elastic.LostItemSearchService;
+import org.lostnomore.backend.item.manager.LostItemRetriever;
+import org.lostnomore.backend.subscribe.domain.Subscribe;
+import org.lostnomore.backend.subscribe.manager.SubscribeRetriever;
+import org.springframework.data.elasticsearch.core.SearchHits;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDate;
+import java.util.*;
+import java.util.stream.Collectors;
 
 @Service
+@RequiredArgsConstructor
 public class SubscribeService {
+
+    private final SubscribeRetriever subscribeRetriever;
+    private final LostItemSearchService lostItemSearchService;
+    private final LostItemRetriever lostItemRetriever;
+
+    @Transactional(readOnly = true)
+    public LostItemsListDto getSubscribeList(
+            final Long userId,
+            final LocalDate dateStart, final LocalDate dateEnd,
+            final String keyword
+    ) {
+        List<Subscribe> subscribes = subscribeRetriever.findByUserId(userId);
+
+        if (keyword != null) {
+            subscribes = subscribes.stream()
+                    .filter(subscribe -> keyword.equals(subscribe.getKeyword()))
+                    .toList();
+        }
+
+        Set<Long> lostItemIds = new HashSet<>();
+
+        for (Subscribe subscribe : subscribes) {
+            SearchHits<LostItemDocument> searchHits = lostItemSearchService.searchLostItemsForSubscription(
+                    dateStart, dateEnd,
+                    subscribe.getKeyword(),
+                    subscribe.getCategory().getId(),
+                    subscribe.getRegion()
+            );
+
+            lostItemIds.addAll(
+                    searchHits.getSearchHits()
+                            .stream()
+                            .map(hit -> hit.getContent().getId())
+                            .collect(Collectors.toSet())
+            );
+        }
+
+        if (lostItemIds.isEmpty()) {
+            return new LostItemsListDto(0, Collections.emptyList());
+        }
+
+        List<LostItem> finalLostItems = lostItemRetriever.findByIdIn(new ArrayList<>(lostItemIds));
+
+        return LostItemsListDto.from(finalLostItems);
+    }
 }

--- a/src/main/java/org/lostnomore/backend/subscribe/service/SubscribeService.java
+++ b/src/main/java/org/lostnomore/backend/subscribe/service/SubscribeService.java
@@ -31,24 +31,7 @@ public class SubscribeService {
         LocalDate dateStart = dateEnd.minusDays(7);
 
         List<Subscribe> subscribes = subscribeRetriever.findByUserId(userId);
-        Set<Long> lostItemIds = new HashSet<>();
-
-        for (Subscribe subscribe : subscribes) {
-            SearchHits<LostItemDocument> searchHits = lostItemSearchService.searchLostItemsForSubscription(
-                    dateStart, dateEnd,
-                    subscribe.getKeyword(),
-                    subscribe.getCategory().getId(),
-                    subscribe.getRegion(),
-                    9
-            );
-
-            lostItemIds.addAll(
-                    searchHits.getSearchHits()
-                            .stream()
-                            .map(hit -> hit.getContent().getId())
-                            .collect(Collectors.toSet())
-            );
-        }
+        Set<Long> lostItemIds = searchLostItemIds(subscribes, dateStart, dateEnd, 9);
 
         if (lostItemIds.isEmpty()) {
             return new RecentItemsDto(Collections.emptyList());
@@ -74,24 +57,7 @@ public class SubscribeService {
                     .toList();
         }
 
-        Set<Long> lostItemIds = new HashSet<>();
-
-        for (Subscribe subscribe : subscribes) {
-            SearchHits<LostItemDocument> searchHits = lostItemSearchService.searchLostItemsForSubscription(
-                    dateStart, dateEnd,
-                    subscribe.getKeyword(),
-                    subscribe.getCategory().getId(),
-                    subscribe.getRegion(),
-                    null
-            );
-
-            lostItemIds.addAll(
-                    searchHits.getSearchHits()
-                            .stream()
-                            .map(hit -> hit.getContent().getId())
-                            .collect(Collectors.toSet())
-            );
-        }
+        Set<Long> lostItemIds = searchLostItemIds(subscribes, dateStart, dateEnd, null);
 
         if (lostItemIds.isEmpty()) {
             return new SubscribeListDto(0, Collections.emptyList(), null, null);
@@ -108,5 +74,28 @@ public class SubscribeService {
         Long nextCursorId = finalLostItems.isEmpty() ? null : finalLostItems.get(finalLostItems.size() - 1).getId();
 
         return SubscribeListDto.from(finalLostItems, nextCursorDate, nextCursorId);
+    }
+
+    private Set<Long> searchLostItemIds(List<Subscribe> subscribes, LocalDate dateStart, LocalDate dateEnd, Integer size) {
+        Set<Long> lostItemIds = new HashSet<>();
+
+        for (Subscribe subscribe : subscribes) {
+            SearchHits<LostItemDocument> searchHits = lostItemSearchService.searchLostItemsForSubscription(
+                    dateStart, dateEnd,
+                    subscribe.getKeyword(),
+                    subscribe.getCategory().getId(),
+                    subscribe.getRegion(),
+                    size
+            );
+
+            lostItemIds.addAll(
+                    searchHits.getSearchHits()
+                            .stream()
+                            .map(hit -> hit.getContent().getId())
+                            .collect(Collectors.toSet())
+            );
+        }
+
+        return lostItemIds;
     }
 }

--- a/src/main/java/org/lostnomore/backend/subscribe/service/SubscribeService.java
+++ b/src/main/java/org/lostnomore/backend/subscribe/service/SubscribeService.java
@@ -2,7 +2,6 @@ package org.lostnomore.backend.subscribe.service;
 
 import lombok.RequiredArgsConstructor;
 import org.lostnomore.backend.item.domain.LostItem;
-import org.lostnomore.backend.item.dto.response.LostItemListDto;
 import org.lostnomore.backend.item.elastic.LostItemDocument;
 import org.lostnomore.backend.item.elastic.LostItemSearchService;
 import org.lostnomore.backend.item.manager.LostItemRetriever;

--- a/src/test/java/org/lostnomore/backend/item/service/LostItemServiceTest.java
+++ b/src/test/java/org/lostnomore/backend/item/service/LostItemServiceTest.java
@@ -85,7 +85,7 @@ class LostItemServiceTest {
         LocalDate startDate = LocalDate.of(2024, 2, 1);
         LocalDate endDate = LocalDate.of(2024, 2, 10);
 
-        when(lostItemSearchService.searchLostItems(any(), any(), any(), any(), any(), any(), any(), any(), any()))
+        when(lostItemSearchService.searchLostItems(any(), any(), any(), any(), any(), any(), any(), any(), any(), any()))
                 .thenReturn(mock(SearchHits.class)); // 그냥 빈 Mock 객체 반환
 
         // when

--- a/src/test/java/org/lostnomore/backend/subscribe/service/SubscribeServiceTest.java
+++ b/src/test/java/org/lostnomore/backend/subscribe/service/SubscribeServiceTest.java
@@ -1,0 +1,162 @@
+package org.lostnomore.backend.subscribe.service;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.lostnomore.backend.common.ServiceTest;
+import org.lostnomore.backend.item.domain.Category;
+import org.lostnomore.backend.item.domain.Location;
+import org.lostnomore.backend.item.domain.LostItem;
+import org.lostnomore.backend.item.elastic.LostItemDocument;
+import org.lostnomore.backend.item.elastic.LostItemSearchService;
+import org.lostnomore.backend.item.manager.LostItemRetriever;
+import org.lostnomore.backend.subscribe.domain.Subscribe;
+import org.lostnomore.backend.subscribe.dto.response.RecentItemsDto;
+import org.lostnomore.backend.subscribe.dto.response.SubscribeListDto;
+import org.lostnomore.backend.subscribe.manager.SubscribeRetriever;
+import org.lostnomore.backend.user.domain.User;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.elasticsearch.core.SearchHit;
+import org.springframework.data.elasticsearch.core.SearchHits;
+
+import java.time.LocalDate;
+import java.util.Collections;
+import java.util.List;
+import java.util.Set;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class SubscribeServiceTest extends ServiceTest {
+
+    @Mock
+    private SubscribeRetriever subscribeRetriever;
+
+    @Mock
+    private LostItemRetriever lostItemRetriever;
+
+    @Mock
+    private LostItemSearchService lostItemSearchService;
+
+    @InjectMocks
+    private SubscribeService subscribeService;
+
+    private Long testUserId;
+    private User testUser;
+    private Category category;
+    private Location location;
+    private Subscribe subscribe;
+    private List<Subscribe> subscribes;
+    private LostItemDocument lostItemDocument;
+    private SearchHit<LostItemDocument> searchHit;
+    private SearchHits<LostItemDocument> searchHits;
+    private LostItem lostItem;
+    private List<LostItem> lostItems;
+    private final LocalDate dateEnd = LocalDate.now().minusDays(1);
+    private final LocalDate dateStart = dateEnd.minusDays(7);
+
+    @BeforeEach
+    void setUp() {
+        testUserId = 1L;
+
+        testUser = User.builder().name("테스트 유저").build();
+        category = Category.builder().name("전자기기").build();
+        location = Location.builder().name("서울").build();
+
+        subscribe = Subscribe.builder()
+                .user(testUser)
+                .keyword("지갑")
+                .region("서울")
+                .category(category)
+                .build();
+        subscribes = List.of(subscribe);
+
+        lostItemDocument = LostItemDocument.builder()
+                .id(100L)
+                .name("지갑")
+                .region("서울")
+                .build();
+
+        searchHit = mock(SearchHit.class);
+        when(searchHit.getContent()).thenReturn(lostItemDocument);
+
+        searchHits = mock(SearchHits.class);
+        when(searchHits.getSearchHits()).thenReturn(List.of(searchHit));
+
+        lostItem = LostItem.builder()
+                .name("지갑")
+                .category(category)
+                .location(location)
+                .build();
+        lostItems = List.of(lostItem);
+    }
+
+    @Test
+    @DisplayName("구독한 키워드에 해당하는 분실물 목록을 반환한다.")
+    void getRecentItemsTest() {
+        // Given
+        when(subscribeRetriever.findByUserId(testUserId)).thenReturn(subscribes);
+        when(lostItemSearchService.searchLostItemsForSubscription(any(), any(), any(), any(), any(), any()))
+                .thenReturn(searchHits);
+        when(lostItemRetriever.findByIdIn(anyList())).thenReturn(lostItems);
+
+        // When
+        RecentItemsDto result = subscribeService.getRecentItems(testUserId);
+
+        // Then
+        assertThat(result.recentItems()).hasSize(1);
+        assertThat(result.recentItems().get(0).name()).isEqualTo(lostItem.getName());
+        assertThat(result.recentItems().get(0).location()).isEqualTo(lostItem.getLocation().getName());
+
+        verify(subscribeRetriever, times(1)).findByUserId(testUserId);
+        verify(lostItemSearchService, times(1)).searchLostItemsForSubscription(any(), any(), any(), any(), any(), any());
+        verify(lostItemRetriever, times(1)).findByIdIn(anyList());
+    }
+
+    @Test
+    @DisplayName("구독한 키워드의 분실물 목록을 정상적으로 반환한다.")
+    void getSubscribeListTest() {
+        // Given
+        when(subscribeRetriever.findByUserId(testUserId)).thenReturn(subscribes);
+        when(lostItemSearchService.searchLostItemsForSubscription(any(), any(), any(), any(), any(), any()))
+                .thenReturn(searchHits);
+        when(lostItemRetriever.findByIdInWithCursorPagination(anyList(), any(), any(), anyInt()))
+                .thenReturn(lostItems);
+
+        // When
+        SubscribeListDto result = subscribeService.getSubscribeList(testUserId, dateStart, dateEnd, null, null, null, 8);
+
+        // Then
+        assertThat(result.lostItems()).hasSize(1);
+        assertThat(result.lostItems().get(0).name()).isEqualTo("지갑");
+        assertThat(result.lostItems().get(0).location()).isEqualTo("서울");
+
+        verify(subscribeRetriever, times(1)).findByUserId(testUserId);
+        verify(lostItemSearchService, times(1)).searchLostItemsForSubscription(any(), any(), any(), any(), any(), any());
+        verify(lostItemRetriever, times(1)).findByIdInWithCursorPagination(anyList(), any(), any(), anyInt());
+    }
+
+    @Test
+    @DisplayName("검색된 분실물이 없으면 빈 목록을 반환한다.")
+    void getSubscribeList_noResult() {
+        // Given
+        when(subscribeRetriever.findByUserId(testUserId)).thenReturn(subscribes);
+        when(lostItemSearchService.searchLostItemsForSubscription(any(), any(), any(), any(), any(), any()))
+                .thenReturn(searchHits);
+        when(lostItemRetriever.findByIdInWithCursorPagination(anyList(), any(), any(), anyInt()))
+                .thenReturn(Collections.emptyList());
+
+        // When
+        SubscribeListDto result = subscribeService.getSubscribeList(testUserId, dateStart, dateEnd, null, null, null, 5);
+
+        // Then
+        assertThat(result.lostItems()).isEmpty();
+        assertThat(result.nextCursorDate()).isNull();
+        assertThat(result.nextCursorId()).isNull();
+    }
+}


### PR DESCRIPTION
## Related issue 🛠
[//]: # (해당하는 이슈 번호 달아주기)
- closed #29 

## Work Description ✏️
[//]: # (작업 내용 간단 소개)
- 분실물 알림 리스트 구현했습니다.
    - 커서 기반 페이징 적용했습니다. (8개 default)
    - keyword가 주어지면 해당 키워드로, keyword가 주어지지 않으면 구독한 keyword 전체로 검색되도록 했습니다.
    - 정렬 기준은 날짜 최신순, 날짜가 같으면 id가 큰 순으로 출력되도록 했습니다.

- 최근 분실물 조회 구현했습니다.
   - 일주일치 분실물 중에 최신순 9개 호출하도록 했습니다.
   - keyword는 따로 없이 구독한 전체가 검색되도록 했습니다.

## Uncompleted Tasks 😅
[//]: # (없다면 N/A)
- [ ] N/A

## To Reviewers 📢
[//]: # (reviewer가 알면 좋은 내용들)