### PR TITLE
[FEAT] 키워드 구독 관련 API 구현 

### DIFF
--- a/src/main/java/org/lostnomore/backend/global/config/WebMvcConfig.java
+++ b/src/main/java/org/lostnomore/backend/global/config/WebMvcConfig.java
@@ -23,7 +23,10 @@ public class WebMvcConfig implements WebMvcConfigurer {
         registry.addInterceptor(new AccessTokenInterceptor(jwtTokenProvider, bearerAuthorizationExtractor))
                 .addPathPatterns("/**")
                 .excludePathPatterns(
-                        "/auth/**"
+                        "/auth/**",
+                        "/test/**",
+                        "/items/search/**",
+                        "/items/count"
                 );
     }
 

--- a/src/main/java/org/lostnomore/backend/global/exception/code/CategoryErrorCode.java
+++ b/src/main/java/org/lostnomore/backend/global/exception/code/CategoryErrorCode.java
@@ -1,0 +1,16 @@
+package org.lostnomore.backend.global.exception.code;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@AllArgsConstructor
+public enum CategoryErrorCode implements DefaultErrorCode {
+    //404 BAD_REQUEST
+    CATEGORY_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 카테고리를 찾을 수 없습니다."),
+    ;
+
+    private HttpStatus httpStatus;
+    private String message;
+}

--- a/src/main/java/org/lostnomore/backend/global/exception/code/LocationErrorCode.java
+++ b/src/main/java/org/lostnomore/backend/global/exception/code/LocationErrorCode.java
@@ -1,0 +1,16 @@
+package org.lostnomore.backend.global.exception.code;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@AllArgsConstructor
+public enum LocationErrorCode implements DefaultErrorCode {
+    //404 BAD_REQUEST
+    LOCATION_REGION_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 지역을 찾을 수 없습니다."),
+    ;
+
+    private HttpStatus httpStatus;
+    private String message;
+}

--- a/src/main/java/org/lostnomore/backend/global/exception/code/SubscribeErrorCode.java
+++ b/src/main/java/org/lostnomore/backend/global/exception/code/SubscribeErrorCode.java
@@ -1,0 +1,19 @@
+package org.lostnomore.backend.global.exception.code;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@AllArgsConstructor
+public enum SubscribeErrorCode implements DefaultErrorCode {
+    //404 BAD_REQUEST
+    SUBSCRIBE_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 구독을 찾을 수 없습니다."),
+
+    //409 CONFLICT
+    SUBSCRIBE_DUPLICATE(HttpStatus.CONFLICT, "이미 등록된 구독 정보입니다.")
+    ;
+
+    private HttpStatus httpStatus;
+    private String message;
+}

--- a/src/main/java/org/lostnomore/backend/global/exception/code/SubscribeErrorCode.java
+++ b/src/main/java/org/lostnomore/backend/global/exception/code/SubscribeErrorCode.java
@@ -7,6 +7,9 @@ import org.springframework.http.HttpStatus;
 @Getter
 @AllArgsConstructor
 public enum SubscribeErrorCode implements DefaultErrorCode {
+    //403 FORBIDDEN
+    SUBSCRIBE_FORBIDDEN(HttpStatus.FORBIDDEN, "해당 구독에 대한 권한이 없습니다."),
+
     //404 BAD_REQUEST
     SUBSCRIBE_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 구독을 찾을 수 없습니다."),
 

--- a/src/main/java/org/lostnomore/backend/global/exception/code/UserErrorCode.java
+++ b/src/main/java/org/lostnomore/backend/global/exception/code/UserErrorCode.java
@@ -1,0 +1,16 @@
+package org.lostnomore.backend.global.exception.code;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@AllArgsConstructor
+public enum UserErrorCode implements DefaultErrorCode {
+    //404 BAD_REQUEST
+    USER_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 유저를 찾을 수 없습니다."),
+    ;
+
+    private HttpStatus httpStatus;
+    private String message;
+}

--- a/src/main/java/org/lostnomore/backend/item/manager/CategoryRetriever.java
+++ b/src/main/java/org/lostnomore/backend/item/manager/CategoryRetriever.java
@@ -1,6 +1,8 @@
 package org.lostnomore.backend.item.manager;
 
 import lombok.RequiredArgsConstructor;
+import org.lostnomore.backend.global.exception.BusinessException;
+import org.lostnomore.backend.global.exception.code.CategoryErrorCode;
 import org.lostnomore.backend.item.domain.Category;
 import org.lostnomore.backend.item.repository.CategoryRepository;
 import org.springframework.stereotype.Component;
@@ -13,6 +15,11 @@ public class CategoryRetriever {
 
     public Category findById(final Long categoryId) {
         return categoryRepository.findById(categoryId)
-                .orElseThrow(() -> new IllegalArgumentException("해당 Category가 존재하지 않습니다."));
+                .orElseThrow(() -> new BusinessException(CategoryErrorCode.CATEGORY_NOT_FOUND));
+    }
+
+    public Category findByName(final String categoryName) {
+        return categoryRepository.findByName(categoryName)
+                .orElseThrow(() -> new BusinessException(CategoryErrorCode.CATEGORY_NOT_FOUND));
     }
 }

--- a/src/main/java/org/lostnomore/backend/item/manager/LocationRetriever.java
+++ b/src/main/java/org/lostnomore/backend/item/manager/LocationRetriever.java
@@ -1,9 +1,12 @@
 package org.lostnomore.backend.item.manager;
 
 import lombok.RequiredArgsConstructor;
+import org.lostnomore.backend.global.exception.BusinessException;
 import org.lostnomore.backend.item.domain.Location;
 import org.lostnomore.backend.item.repository.LocationRepository;
 import org.springframework.stereotype.Component;
+
+import java.util.List;
 
 @Component
 @RequiredArgsConstructor
@@ -13,5 +16,9 @@ public class LocationRetriever {
 
     public Location findByName(final String location) {
         return locationRepository.findByName(location);
+    }
+
+    public List<Location> findByRegion(final String region) {
+        return locationRepository.findByRegion(region);
     }
 }

--- a/src/main/java/org/lostnomore/backend/item/repository/CategoryRepository.java
+++ b/src/main/java/org/lostnomore/backend/item/repository/CategoryRepository.java
@@ -3,5 +3,8 @@ package org.lostnomore.backend.item.repository;
 import org.lostnomore.backend.item.domain.Category;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.Optional;
+
 public interface CategoryRepository extends JpaRepository<Category, Long> {
+    Optional<Category> findByName(String categoryName);
 }

--- a/src/main/java/org/lostnomore/backend/item/repository/LocationRepository.java
+++ b/src/main/java/org/lostnomore/backend/item/repository/LocationRepository.java
@@ -3,9 +3,13 @@ package org.lostnomore.backend.item.repository;
 import org.lostnomore.backend.item.domain.Location;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import javax.swing.text.html.Option;
+import java.util.List;
 import java.util.Optional;
 
 public interface LocationRepository extends JpaRepository<Location, Long> {
 
     Location findByName(String name);
+
+    List<Location> findByRegion(String region);
 }

--- a/src/main/java/org/lostnomore/backend/subscribe/controller/SubscribeController.java
+++ b/src/main/java/org/lostnomore/backend/subscribe/controller/SubscribeController.java
@@ -1,6 +1,7 @@
 package org.lostnomore.backend.subscribe.controller;
 
 import lombok.RequiredArgsConstructor;
+import org.lostnomore.backend.global.LoginUser;
 import org.lostnomore.backend.global.dto.ResponseDto;
 import org.lostnomore.backend.subscribe.dto.response.RecentItemsDto;
 import org.lostnomore.backend.subscribe.dto.response.SubscribeListDto;
@@ -22,14 +23,14 @@ public class SubscribeController {
 
     @GetMapping("items/recent")
     public ResponseEntity<ResponseDto<RecentItemsDto>> getRecentItems (
-            final Long userId
+            @LoginUser final Long userId
     ) {
         return ResponseEntity.status(HttpStatus.OK).body(ResponseDto.success(subscribeService.getRecentItems(userId)));
     }
 
     @GetMapping("/subscribe/list")
     public ResponseEntity<ResponseDto<SubscribeListDto>> getSubscribeList(
-            final Long userId,
+            @LoginUser final Long userId,
             @RequestParam @DateTimeFormat(pattern = "yyyy-MM-dd") LocalDate date_start,
             @RequestParam @DateTimeFormat(pattern = "yyyy-MM-dd") LocalDate date_end,
             @RequestParam(required = false) String keyword,

--- a/src/main/java/org/lostnomore/backend/subscribe/controller/SubscribeController.java
+++ b/src/main/java/org/lostnomore/backend/subscribe/controller/SubscribeController.java
@@ -6,6 +6,7 @@ import org.lostnomore.backend.global.dto.ResponseDto;
 import org.lostnomore.backend.subscribe.dto.request.SubscribeCreateDto;
 import org.lostnomore.backend.subscribe.dto.response.RecentItemsDto;
 import org.lostnomore.backend.subscribe.dto.response.SubscribeListDto;
+import org.lostnomore.backend.subscribe.dto.response.SubscribesDto;
 import org.lostnomore.backend.subscribe.service.SubscribeService;
 import org.springframework.format.annotation.DateTimeFormat;
 import org.springframework.http.HttpStatus;
@@ -50,5 +51,12 @@ public class SubscribeController {
     ) {
         subscribeService.createSubscribe(userId, subscribeCreateDto);
         return ResponseEntity.ok().body(ResponseDto.success());
+    }
+
+    @GetMapping("/subscribe")
+    public ResponseEntity<ResponseDto<SubscribesDto>> getSubscribes (
+            @LoginUser final Long userId
+    ) {
+        return ResponseEntity.ok().body(ResponseDto.success(subscribeService.getSubscribes(userId)));
     }
 }

--- a/src/main/java/org/lostnomore/backend/subscribe/controller/SubscribeController.java
+++ b/src/main/java/org/lostnomore/backend/subscribe/controller/SubscribeController.java
@@ -3,15 +3,14 @@ package org.lostnomore.backend.subscribe.controller;
 import lombok.RequiredArgsConstructor;
 import org.lostnomore.backend.global.LoginUser;
 import org.lostnomore.backend.global.dto.ResponseDto;
+import org.lostnomore.backend.subscribe.dto.request.SubscribeCreateDto;
 import org.lostnomore.backend.subscribe.dto.response.RecentItemsDto;
 import org.lostnomore.backend.subscribe.dto.response.SubscribeListDto;
 import org.lostnomore.backend.subscribe.service.SubscribeService;
 import org.springframework.format.annotation.DateTimeFormat;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.RequestParam;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 import java.time.LocalDate;
 
@@ -42,5 +41,14 @@ public class SubscribeController {
                 userId, date_start, date_end, keyword,
                 cursorDate, cursorId, size
         )));
+    }
+
+    @PostMapping("/subscribe")
+    public ResponseEntity<ResponseDto<Void>> createSubscribe(
+            @LoginUser final Long userId,
+            @RequestBody SubscribeCreateDto subscribeCreateDto
+    ) {
+        subscribeService.createSubscribe(userId, subscribeCreateDto);
+        return ResponseEntity.ok().body(ResponseDto.success());
     }
 }

--- a/src/main/java/org/lostnomore/backend/subscribe/controller/SubscribeController.java
+++ b/src/main/java/org/lostnomore/backend/subscribe/controller/SubscribeController.java
@@ -59,4 +59,13 @@ public class SubscribeController {
     ) {
         return ResponseEntity.ok().body(ResponseDto.success(subscribeService.getSubscribes(userId)));
     }
+
+    @DeleteMapping("/subscribe/{subscribeId}")
+    public ResponseEntity<ResponseDto<Void>> deleteSubscribe (
+            @LoginUser final Long userId,
+            @PathVariable Long subscribeId
+    ) {
+        subscribeService.deleteSubscribe(userId, subscribeId);
+        return ResponseEntity.ok().body(ResponseDto.success());
+    }
 }

--- a/src/main/java/org/lostnomore/backend/subscribe/controller/SubscribeController.java
+++ b/src/main/java/org/lostnomore/backend/subscribe/controller/SubscribeController.java
@@ -63,9 +63,19 @@ public class SubscribeController {
     @DeleteMapping("/subscribe/{subscribeId}")
     public ResponseEntity<ResponseDto<Void>> deleteSubscribe (
             @LoginUser final Long userId,
-            @PathVariable Long subscribeId
+            @PathVariable final Long subscribeId
     ) {
         subscribeService.deleteSubscribe(userId, subscribeId);
+        return ResponseEntity.ok().body(ResponseDto.success());
+    }
+
+    @PutMapping("/subscribe/{subscribeId}")
+    public ResponseEntity<ResponseDto<Void>> updateSubscribe (
+            @LoginUser final Long userId,
+            @PathVariable final Long subscribeId,
+            @RequestBody final SubscribeCreateDto subscribeCreateDto
+    ) {
+        subscribeService.updateSubscribe(userId, subscribeId, subscribeCreateDto);
         return ResponseEntity.ok().body(ResponseDto.success());
     }
 }

--- a/src/main/java/org/lostnomore/backend/subscribe/domain/Subscribe.java
+++ b/src/main/java/org/lostnomore/backend/subscribe/domain/Subscribe.java
@@ -1,14 +1,6 @@
 package org.lostnomore.backend.subscribe.domain;
 
-import jakarta.persistence.Column;
-import jakarta.persistence.Entity;
-import jakarta.persistence.FetchType;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.GenerationType;
-import jakarta.persistence.Id;
-import jakarta.persistence.JoinColumn;
-import jakarta.persistence.ManyToOne;
-import jakarta.persistence.Table;
+import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
@@ -18,7 +10,10 @@ import org.lostnomore.backend.item.domain.Category;
 import org.lostnomore.backend.user.domain.User;
 
 @Getter
-@Table(name = "subscribe")
+@Table(name = "subscribe",
+        uniqueConstraints = {
+                @UniqueConstraint(name = "unique_user_keyword", columnNames = {"user_id", "category_id", "keyword", "region"})
+        })
 @Entity
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Subscribe extends BaseEntity {

--- a/src/main/java/org/lostnomore/backend/subscribe/domain/Subscribe.java
+++ b/src/main/java/org/lostnomore/backend/subscribe/domain/Subscribe.java
@@ -44,4 +44,14 @@ public class Subscribe extends BaseEntity {
         this.keyword = keyword;
         this.region = region;
     }
+
+    public void updateSubscribe(
+            String keyword,
+            Category category,
+            String region
+    ) {
+        this.keyword = keyword;
+        this.category = category;
+        this.region = region;
+    }
 }

--- a/src/main/java/org/lostnomore/backend/subscribe/dto/request/SubscribeCreateDto.java
+++ b/src/main/java/org/lostnomore/backend/subscribe/dto/request/SubscribeCreateDto.java
@@ -1,0 +1,8 @@
+package org.lostnomore.backend.subscribe.dto.request;
+
+public record SubscribeCreateDto(
+        String keyword,
+        String category,
+        String region
+) {
+}

--- a/src/main/java/org/lostnomore/backend/subscribe/dto/response/SubscribesDto.java
+++ b/src/main/java/org/lostnomore/backend/subscribe/dto/response/SubscribesDto.java
@@ -1,0 +1,35 @@
+package org.lostnomore.backend.subscribe.dto.response;
+
+import org.lostnomore.backend.subscribe.domain.Subscribe;
+
+import java.util.List;
+
+public record SubscribesDto(
+        int totalCount,
+        List<SubscribeDto> subscribes
+) {
+    public static SubscribesDto from (List<Subscribe> subscribes) {
+        return new SubscribesDto(
+                subscribes.size(),
+                subscribes.stream()
+                        .map(SubscribeDto::from)
+                        .toList()
+        );
+    }
+
+    public record SubscribeDto(
+            Long subscribeId,
+            String keyword,
+            String category,
+            String region
+    ) {
+        public static SubscribeDto from(Subscribe subscribe) {
+            return new SubscribeDto(
+                    subscribe.getId(),
+                    subscribe.getKeyword(),
+                    subscribe.getCategory().getName(),
+                    subscribe.getRegion()
+            );
+        }
+    }
+}

--- a/src/main/java/org/lostnomore/backend/subscribe/manager/SubscribeCreator.java
+++ b/src/main/java/org/lostnomore/backend/subscribe/manager/SubscribeCreator.java
@@ -1,0 +1,18 @@
+package org.lostnomore.backend.subscribe.manager;
+
+import lombok.RequiredArgsConstructor;
+import org.lostnomore.backend.subscribe.domain.Subscribe;
+import org.lostnomore.backend.subscribe.repository.SubscribeRepository;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class SubscribeCreator {
+
+    private final SubscribeRepository subscribeRepository;
+
+
+    public void save(final Subscribe subscribe) {
+        subscribeRepository.save(subscribe);
+    }
+}

--- a/src/main/java/org/lostnomore/backend/subscribe/manager/SubscribeEditor.java
+++ b/src/main/java/org/lostnomore/backend/subscribe/manager/SubscribeEditor.java
@@ -1,0 +1,28 @@
+package org.lostnomore.backend.subscribe.manager;
+
+import lombok.RequiredArgsConstructor;
+import org.lostnomore.backend.item.domain.Category;
+import org.lostnomore.backend.subscribe.domain.Subscribe;
+import org.lostnomore.backend.subscribe.dto.request.SubscribeCreateDto;
+import org.lostnomore.backend.subscribe.repository.SubscribeRepository;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class SubscribeEditor {
+
+    private final SubscribeRepository subscribeRepository;
+
+    public void updateSubscribe(
+            final Subscribe subscribe,
+            final String keyword,
+            final Category category,
+            final String region
+            ) {
+        subscribe.updateSubscribe(
+                keyword,
+                category,
+                region
+        );
+    }
+}

--- a/src/main/java/org/lostnomore/backend/subscribe/manager/SubscribeRemover.java
+++ b/src/main/java/org/lostnomore/backend/subscribe/manager/SubscribeRemover.java
@@ -1,0 +1,17 @@
+package org.lostnomore.backend.subscribe.manager;
+
+import lombok.RequiredArgsConstructor;
+import org.lostnomore.backend.subscribe.repository.SubscribeRepository;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class SubscribeRemover {
+
+    private final SubscribeRepository subscribeRepository;
+
+
+    public void deleteById(final Long subscribeId) {
+        subscribeRepository.deleteById(subscribeId);
+    }
+}

--- a/src/main/java/org/lostnomore/backend/subscribe/manager/SubscribeRetriever.java
+++ b/src/main/java/org/lostnomore/backend/subscribe/manager/SubscribeRetriever.java
@@ -1,6 +1,8 @@
 package org.lostnomore.backend.subscribe.manager;
 
 import lombok.RequiredArgsConstructor;
+import org.lostnomore.backend.global.exception.BusinessException;
+import org.lostnomore.backend.global.exception.code.SubscribeErrorCode;
 import org.lostnomore.backend.subscribe.domain.Subscribe;
 import org.lostnomore.backend.subscribe.repository.SubscribeRepository;
 import org.springframework.stereotype.Component;
@@ -15,5 +17,10 @@ public class SubscribeRetriever {
 
     public List<Subscribe> findByUserId(final Long userId) {
         return subscribeRepository.findByUserId(userId);
+    }
+
+    public Subscribe findById(Long subscribeId) {
+        return subscribeRepository.findById(subscribeId)
+                .orElseThrow(() -> new BusinessException(SubscribeErrorCode.SUBSCRIBE_NOT_FOUND));
     }
 }

--- a/src/main/java/org/lostnomore/backend/subscribe/repository/SubscribeRepository.java
+++ b/src/main/java/org/lostnomore/backend/subscribe/repository/SubscribeRepository.java
@@ -2,11 +2,17 @@ package org.lostnomore.backend.subscribe.repository;
 
 import org.lostnomore.backend.subscribe.domain.Subscribe;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
 
 public interface SubscribeRepository extends JpaRepository<Subscribe, Long> {
 
+    @Query("""
+       SELECT s FROM Subscribe s
+       JOIN FETCH s.category
+       WHERE s.user.id = :userId
+       """)
     List<Subscribe> findByUserId(Long userId);
 }

--- a/src/main/java/org/lostnomore/backend/subscribe/service/SubscribeService.java
+++ b/src/main/java/org/lostnomore/backend/subscribe/service/SubscribeService.java
@@ -1,6 +1,7 @@
 package org.lostnomore.backend.subscribe.service;
 
 import lombok.RequiredArgsConstructor;
+import org.lostnomore.backend.global.dto.ResponseDto;
 import org.lostnomore.backend.global.exception.BusinessException;
 import org.lostnomore.backend.global.exception.code.SubscribeErrorCode;
 import org.lostnomore.backend.item.domain.Category;
@@ -13,6 +14,7 @@ import org.lostnomore.backend.subscribe.domain.Subscribe;
 import org.lostnomore.backend.subscribe.dto.request.SubscribeCreateDto;
 import org.lostnomore.backend.subscribe.dto.response.RecentItemsDto;
 import org.lostnomore.backend.subscribe.dto.response.SubscribeListDto;
+import org.lostnomore.backend.subscribe.dto.response.SubscribesDto;
 import org.lostnomore.backend.subscribe.manager.SubscribeCreator;
 import org.lostnomore.backend.subscribe.manager.SubscribeRetriever;
 import org.lostnomore.backend.user.domain.User;
@@ -130,5 +132,9 @@ public class SubscribeService {
         } catch (DataIntegrityViolationException e) {
             throw new BusinessException(SubscribeErrorCode.SUBSCRIBE_DUPLICATE);
         }
+    }
+
+    public SubscribesDto getSubscribes(final Long userId) {
+        return SubscribesDto.from(subscribeRetriever.findByUserId(userId));
     }
 }

--- a/src/main/java/org/lostnomore/backend/subscribe/service/SubscribeService.java
+++ b/src/main/java/org/lostnomore/backend/subscribe/service/SubscribeService.java
@@ -3,12 +3,15 @@ package org.lostnomore.backend.subscribe.service;
 import lombok.RequiredArgsConstructor;
 import org.lostnomore.backend.global.dto.ResponseDto;
 import org.lostnomore.backend.global.exception.BusinessException;
+import org.lostnomore.backend.global.exception.code.LocationErrorCode;
 import org.lostnomore.backend.global.exception.code.SubscribeErrorCode;
 import org.lostnomore.backend.item.domain.Category;
+import org.lostnomore.backend.item.domain.Location;
 import org.lostnomore.backend.item.domain.LostItem;
 import org.lostnomore.backend.item.elastic.LostItemDocument;
 import org.lostnomore.backend.item.elastic.LostItemSearchService;
 import org.lostnomore.backend.item.manager.CategoryRetriever;
+import org.lostnomore.backend.item.manager.LocationRetriever;
 import org.lostnomore.backend.item.manager.LostItemRetriever;
 import org.lostnomore.backend.subscribe.domain.Subscribe;
 import org.lostnomore.backend.subscribe.dto.request.SubscribeCreateDto;
@@ -42,6 +45,7 @@ public class SubscribeService {
     private final SubscribeCreator subscribeCreator;
     private final SubscribeRemover subscribeRemover;
     private final SubscribeEditor subscribeEditor;
+    private final LocationRetriever locationRetriever;
 
     @Transactional(readOnly = true)
     public RecentItemsDto getRecentItems(final Long userId) {
@@ -123,7 +127,8 @@ public class SubscribeService {
             final SubscribeCreateDto subscribeCreateDto
     ) {
        User user = userRetriever.findById(userId);
-        Category category = categoryRetriever.findByName(subscribeCreateDto.category());
+       validateRegionExists(subscribeCreateDto.region());
+       Category category = categoryRetriever.findByName(subscribeCreateDto.category());
 
        Subscribe subscribe = Subscribe.builder()
                .user(user)
@@ -163,6 +168,7 @@ public class SubscribeService {
     ) {
         Subscribe subscribe = subscribeRetriever.findById(subscribeId);
         validateSubscribeOwner(userId, subscribe);
+        validateRegionExists(subscribeDto.region());
 
         Category category = categoryRetriever.findByName(subscribeDto.category());
         subscribeEditor.updateSubscribe(subscribe, subscribeDto.keyword(), category, subscribeDto.region());
@@ -171,6 +177,14 @@ public class SubscribeService {
     private void validateSubscribeOwner(Long userId, Subscribe subscribe) {
         if (!subscribe.getUser().getId().equals(userId)) {
             throw new BusinessException(SubscribeErrorCode.SUBSCRIBE_FORBIDDEN);
+        }
+    }
+
+    private void validateRegionExists(String region) {
+        List<Location> locations = locationRetriever.findByRegion(region);
+
+        if (locations.isEmpty()) {
+            throw new BusinessException(LocationErrorCode.LOCATION_REGION_NOT_FOUND);
         }
     }
 }

--- a/src/main/java/org/lostnomore/backend/subscribe/service/SubscribeService.java
+++ b/src/main/java/org/lostnomore/backend/subscribe/service/SubscribeService.java
@@ -16,6 +16,7 @@ import org.lostnomore.backend.subscribe.dto.response.RecentItemsDto;
 import org.lostnomore.backend.subscribe.dto.response.SubscribeListDto;
 import org.lostnomore.backend.subscribe.dto.response.SubscribesDto;
 import org.lostnomore.backend.subscribe.manager.SubscribeCreator;
+import org.lostnomore.backend.subscribe.manager.SubscribeRemover;
 import org.lostnomore.backend.subscribe.manager.SubscribeRetriever;
 import org.lostnomore.backend.user.domain.User;
 import org.lostnomore.backend.user.manager.UserRetriever;
@@ -38,6 +39,7 @@ public class SubscribeService {
     private final UserRetriever userRetriever;
     private final CategoryRetriever categoryRetriever;
     private final SubscribeCreator subscribeCreator;
+    private final SubscribeRemover subscribeRemover;
 
     @Transactional(readOnly = true)
     public RecentItemsDto getRecentItems(final Long userId) {
@@ -136,5 +138,18 @@ public class SubscribeService {
 
     public SubscribesDto getSubscribes(final Long userId) {
         return SubscribesDto.from(subscribeRetriever.findByUserId(userId));
+    }
+
+    public void deleteSubscribe(
+            final Long userId,
+            final Long subscribeId
+    ) {
+        Subscribe subscribe = subscribeRetriever.findById(subscribeId);
+
+        if (!subscribe.getUser().getId().equals(userId)) {
+            throw new BusinessException(SubscribeErrorCode.SUBSCRIBE_FORBIDDEN);
+        }
+
+        subscribeRemover.deleteById(subscribeId);
     }
 }

--- a/src/main/java/org/lostnomore/backend/subscribe/service/SubscribeService.java
+++ b/src/main/java/org/lostnomore/backend/subscribe/service/SubscribeService.java
@@ -1,14 +1,23 @@
 package org.lostnomore.backend.subscribe.service;
 
 import lombok.RequiredArgsConstructor;
+import org.lostnomore.backend.global.exception.BusinessException;
+import org.lostnomore.backend.global.exception.code.SubscribeErrorCode;
+import org.lostnomore.backend.item.domain.Category;
 import org.lostnomore.backend.item.domain.LostItem;
 import org.lostnomore.backend.item.elastic.LostItemDocument;
 import org.lostnomore.backend.item.elastic.LostItemSearchService;
+import org.lostnomore.backend.item.manager.CategoryRetriever;
 import org.lostnomore.backend.item.manager.LostItemRetriever;
 import org.lostnomore.backend.subscribe.domain.Subscribe;
+import org.lostnomore.backend.subscribe.dto.request.SubscribeCreateDto;
 import org.lostnomore.backend.subscribe.dto.response.RecentItemsDto;
 import org.lostnomore.backend.subscribe.dto.response.SubscribeListDto;
+import org.lostnomore.backend.subscribe.manager.SubscribeCreator;
 import org.lostnomore.backend.subscribe.manager.SubscribeRetriever;
+import org.lostnomore.backend.user.domain.User;
+import org.lostnomore.backend.user.manager.UserRetriever;
+import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.data.elasticsearch.core.SearchHits;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -24,6 +33,9 @@ public class SubscribeService {
     private final SubscribeRetriever subscribeRetriever;
     private final LostItemSearchService lostItemSearchService;
     private final LostItemRetriever lostItemRetriever;
+    private final UserRetriever userRetriever;
+    private final CategoryRetriever categoryRetriever;
+    private final SubscribeCreator subscribeCreator;
 
     @Transactional(readOnly = true)
     public RecentItemsDto getRecentItems(final Long userId) {
@@ -97,5 +109,26 @@ public class SubscribeService {
         }
 
         return lostItemIds;
+    }
+
+    public void createSubscribe(
+            final Long userId,
+            final SubscribeCreateDto subscribeCreateDto
+    ) {
+       User user = userRetriever.findById(userId);
+        Category category = categoryRetriever.findByName(subscribeCreateDto.category());
+
+       Subscribe subscribe = Subscribe.builder()
+               .user(user)
+               .keyword(subscribeCreateDto.keyword())
+               .category(category)
+               .region(subscribeCreateDto.region())
+               .build();
+
+        try {
+            subscribeCreator.save(subscribe);
+        } catch (DataIntegrityViolationException e) {
+            throw new BusinessException(SubscribeErrorCode.SUBSCRIBE_DUPLICATE);
+        }
     }
 }

--- a/src/main/java/org/lostnomore/backend/subscribe/service/SubscribeService.java
+++ b/src/main/java/org/lostnomore/backend/subscribe/service/SubscribeService.java
@@ -16,6 +16,7 @@ import org.lostnomore.backend.subscribe.dto.response.RecentItemsDto;
 import org.lostnomore.backend.subscribe.dto.response.SubscribeListDto;
 import org.lostnomore.backend.subscribe.dto.response.SubscribesDto;
 import org.lostnomore.backend.subscribe.manager.SubscribeCreator;
+import org.lostnomore.backend.subscribe.manager.SubscribeEditor;
 import org.lostnomore.backend.subscribe.manager.SubscribeRemover;
 import org.lostnomore.backend.subscribe.manager.SubscribeRetriever;
 import org.lostnomore.backend.user.domain.User;
@@ -40,6 +41,7 @@ public class SubscribeService {
     private final CategoryRetriever categoryRetriever;
     private final SubscribeCreator subscribeCreator;
     private final SubscribeRemover subscribeRemover;
+    private final SubscribeEditor subscribeEditor;
 
     @Transactional(readOnly = true)
     public RecentItemsDto getRecentItems(final Long userId) {
@@ -115,6 +117,7 @@ public class SubscribeService {
         return lostItemIds;
     }
 
+    @Transactional
     public void createSubscribe(
             final Long userId,
             final SubscribeCreateDto subscribeCreateDto
@@ -136,20 +139,38 @@ public class SubscribeService {
         }
     }
 
+    @Transactional(readOnly = true)
     public SubscribesDto getSubscribes(final Long userId) {
         return SubscribesDto.from(subscribeRetriever.findByUserId(userId));
     }
 
+    @Transactional
     public void deleteSubscribe(
             final Long userId,
             final Long subscribeId
     ) {
         Subscribe subscribe = subscribeRetriever.findById(subscribeId);
+        validateSubscribeOwner(userId, subscribe);
 
+        subscribeRemover.deleteById(subscribeId);
+    }
+
+    @Transactional
+    public void updateSubscribe(
+            final Long userId,
+            final Long subscribeId,
+            final SubscribeCreateDto subscribeDto
+    ) {
+        Subscribe subscribe = subscribeRetriever.findById(subscribeId);
+        validateSubscribeOwner(userId, subscribe);
+
+        Category category = categoryRetriever.findByName(subscribeDto.category());
+        subscribeEditor.updateSubscribe(subscribe, subscribeDto.keyword(), category, subscribeDto.region());
+    }
+
+    private void validateSubscribeOwner(Long userId, Subscribe subscribe) {
         if (!subscribe.getUser().getId().equals(userId)) {
             throw new BusinessException(SubscribeErrorCode.SUBSCRIBE_FORBIDDEN);
         }
-
-        subscribeRemover.deleteById(subscribeId);
     }
 }

--- a/src/main/java/org/lostnomore/backend/user/manager/UserRetriever.java
+++ b/src/main/java/org/lostnomore/backend/user/manager/UserRetriever.java
@@ -1,6 +1,8 @@
 package org.lostnomore.backend.user.manager;
 
 import lombok.RequiredArgsConstructor;
+import org.lostnomore.backend.global.exception.BusinessException;
+import org.lostnomore.backend.global.exception.code.UserErrorCode;
 import org.lostnomore.backend.user.domain.SocialType;
 import org.lostnomore.backend.user.domain.User;
 import org.lostnomore.backend.user.repository.UserRepository;
@@ -15,5 +17,10 @@ public class UserRetriever {
     public User findByEmailAndSocialType(String email, SocialType socialType) {
         return userRepository.findByEmailAndSocialType(email, socialType)
                 .orElse(null);
+    }
+
+    public User findById(final Long userId) {
+        return userRepository.findById(userId)
+                .orElseThrow(() -> new BusinessException(UserErrorCode.USER_NOT_FOUND));
     }
 }

--- a/src/test/java/org/lostnomore/backend/subscribe/repository/SubscribeRepositoryTest.java
+++ b/src/test/java/org/lostnomore/backend/subscribe/repository/SubscribeRepositoryTest.java
@@ -45,7 +45,7 @@ class SubscribeRepositoryTest extends RepositoryTest {
     @BeforeEach
     void setUp() {
         testUser = userRepository.save(
-                User.builder().name("테스트 유저").email("test@gmail.com").socialType(SocialType.KAKAO).build()
+                User.builder().name("테스트 유저").email("test@gmail.com").socialType(SocialType.KAKAO).providerId("testProviderId").build()
         );
         testCategory = categoryRepository.save(Category.builder().name("지갑").build());
         testLocation = locationRepository.save(

--- a/src/test/java/org/lostnomore/backend/subscribe/repository/SubscribeRepositoryTest.java
+++ b/src/test/java/org/lostnomore/backend/subscribe/repository/SubscribeRepositoryTest.java
@@ -18,7 +18,6 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 import org.springframework.dao.DataIntegrityViolationException;
 
-import java.lang.reflect.Field;
 import java.util.List;
 import java.util.Optional;
 

--- a/src/test/java/org/lostnomore/backend/subscribe/repository/SubscribeRepositoryTest.java
+++ b/src/test/java/org/lostnomore/backend/subscribe/repository/SubscribeRepositoryTest.java
@@ -1,0 +1,212 @@
+package org.lostnomore.backend.subscribe.repository;
+
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.lostnomore.backend.common.RepositoryTest;
+import org.lostnomore.backend.item.domain.Category;
+import org.lostnomore.backend.item.domain.Location;
+import org.lostnomore.backend.item.repository.CategoryRepository;
+import org.lostnomore.backend.item.repository.LocationRepository;
+import org.lostnomore.backend.subscribe.domain.Subscribe;
+import org.lostnomore.backend.user.domain.SocialType;
+import org.lostnomore.backend.user.domain.User;
+import org.lostnomore.backend.user.repository.UserRepository;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.dao.DataIntegrityViolationException;
+
+import java.lang.reflect.Field;
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.Assertions.*;
+
+@DataJpaTest
+class SubscribeRepositoryTest extends RepositoryTest {
+
+    @Autowired
+    private SubscribeRepository subscribeRepository;
+
+    @Autowired
+    private UserRepository userRepository;
+
+    @Autowired
+    private CategoryRepository categoryRepository;
+
+    @Autowired
+    private LocationRepository locationRepository;
+
+    @PersistenceContext
+    private EntityManager entityManager;
+
+    private User testUser;
+    private Category testCategory;
+    private Location testLocation;
+
+    @BeforeEach
+    void setUp() {
+        testUser = userRepository.save(
+                User.builder().name("테스트 유저").email("test@gmail.com").socialType(SocialType.KAKAO).build()
+        );
+        testCategory = categoryRepository.save(Category.builder().name("지갑").build());
+        testLocation = locationRepository.save(
+                Location.builder().name("서울경찰서").region("서울").latitude(37.125).longitude(127.124).build()
+        );
+    }
+
+    @Test
+    @DisplayName("구독이 정상적으로 생성된다.")
+    void createSubscribeTest() {
+        // Given
+        Subscribe subscribe = Subscribe.builder()
+                .user(testUser)
+                .keyword("고양이지갑")
+                .category(testCategory)
+                .region(testLocation.getRegion())
+                .build();
+
+        // When
+        Subscribe savedSubscribe = subscribeRepository.save(subscribe);
+
+        // Then
+        Optional<Subscribe> foundSubscribe = subscribeRepository.findById(savedSubscribe.getId());
+        assertThat(foundSubscribe).isPresent();
+        assertThat(foundSubscribe.get().getKeyword()).isEqualTo("고양이지갑");
+        assertThat(foundSubscribe.get().getUser()).isEqualTo(testUser);
+        assertThat(foundSubscribe.get().getCategory()).isEqualTo(testCategory);
+        assertThat(foundSubscribe.get().getRegion()).isEqualTo(testLocation.getRegion());
+    }
+
+    @Test
+    @DisplayName("같은 사용자가 동일한 키워드와 지역으로 중복 구독하면 예외가 발생한다.")
+    void createSubscribe_DuplicateTest() {
+        // Given
+        Subscribe subscribe1 = Subscribe.builder()
+                .user(testUser)
+                .keyword("고양이지갑")
+                .category(testCategory)
+                .region(testLocation.getRegion())
+                .build();
+
+        Subscribe subscribe2 = Subscribe.builder()
+                .user(testUser)
+                .keyword("고양이지갑")
+                .category(testCategory)
+                .region(testLocation.getRegion())
+                .build();
+
+        subscribeRepository.save(subscribe1);
+//        entityManager.flush();
+//        entityManager.clear();
+
+        // When & Then
+        assertThatThrownBy(() -> subscribeRepository.save(subscribe2))
+                .isInstanceOf(DataIntegrityViolationException.class);
+    }
+
+    @Test
+    @DisplayName("특정 사용자의 구독 목록을 조회한다.")
+    void getSubscribesTest() {
+        // Given
+        Subscribe subscribe1 = Subscribe.builder()
+                .user(testUser)
+                .keyword("노트북")
+                .category(testCategory)
+                .region(testLocation.getRegion())
+                .build();
+
+        Subscribe subscribe2 = Subscribe.builder()
+                .user(testUser)
+                .keyword("에어팟")
+                .category(testCategory)
+                .region(testLocation.getRegion())
+                .build();
+
+        subscribeRepository.save(subscribe1);
+        subscribeRepository.save(subscribe2);
+
+        // When
+        List<Subscribe> subscribes = subscribeRepository.findByUserId(testUser.getId());
+
+        // Then
+        assertThat(subscribes.size()).isEqualTo(2);
+        assertThat(subscribes).extracting("keyword").containsExactlyInAnyOrder("노트북", "에어팟");
+    }
+
+    @Test
+    @DisplayName("구독을 삭제하면 데이터베이스에서 제거된다.")
+    void deleteSubscribeTest() {
+        // Given
+        Subscribe subscribe = Subscribe.builder()
+                .user(testUser)
+                .keyword("노트북")
+                .category(testCategory)
+                .region(testLocation.getRegion())
+                .build();
+
+        Subscribe savedSubscribe = subscribeRepository.save(subscribe);
+
+        // When
+        subscribeRepository.deleteById(savedSubscribe.getId());
+
+        // Then
+        Optional<Subscribe> foundSubscribe = subscribeRepository.findById(savedSubscribe.getId());
+        assertThat(foundSubscribe.isPresent()).isFalse();
+    }
+
+    @Test
+    @DisplayName("구독 정보를 수정할 수 있다.")
+    void updateSubscribeTest() {
+        // Given
+        Subscribe subscribe = Subscribe.builder()
+                .user(testUser)
+                .keyword("노트북")
+                .category(testCategory)
+                .region(testLocation.getRegion())
+                .build();
+
+        Subscribe savedSubscribe = subscribeRepository.save(subscribe);
+
+        // When
+        Subscribe foundSubscribe = subscribeRepository.findById(savedSubscribe.getId()).orElseThrow();
+        foundSubscribe.updateSubscribe("아이패드", testCategory, "부산");
+
+        // Then
+        Subscribe updatedSubscribe = subscribeRepository.findById(savedSubscribe.getId()).orElseThrow();
+        assertThat(updatedSubscribe.getKeyword()).isEqualTo("아이패드");
+    }
+
+
+//    @Test
+//    @DisplayName("구독 정보를 수정할 수 있다.")
+//    void updateSubscribeTest() {
+//        // Given
+//        Subscribe subscribe = Subscribe.builder()
+//                .user(testUser)
+//                .keyword("태블릿")
+//                .category(testCategory)
+//                .region(testLocation.getName())
+//                .build();
+//
+//        Subscribe savedSubscribe = subscribeRepository.save(subscribe);
+//        entityManager.flush();
+//        entityManager.clear();
+//
+//        // When
+//        Subscribe foundSubscribe = subscribeRepository.findById(savedSubscribe.getId()).orElseThrow();
+//        foundSubscribe.updateKeyword("스마트폰");
+//        subscribeRepository.save(foundSubscribe);
+//        entityManager.flush();
+//        entityManager.clear();
+//
+//        // Then
+//        Subscribe updatedSubscribe = subscribeRepository.findById(savedSubscribe.getId()).orElseThrow();
+//        assertThat(updatedSubscribe.getKeyword()).isEqualTo("스마트폰");
+//    }
+
+}

--- a/src/test/java/org/lostnomore/backend/subscribe/repository/SubscribeRepositoryTest.java
+++ b/src/test/java/org/lostnomore/backend/subscribe/repository/SubscribeRepositoryTest.java
@@ -1,7 +1,5 @@
 package org.lostnomore.backend.subscribe.repository;
 
-import jakarta.persistence.EntityManager;
-import jakarta.persistence.PersistenceContext;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -39,9 +37,6 @@ class SubscribeRepositoryTest extends RepositoryTest {
 
     @Autowired
     private LocationRepository locationRepository;
-
-    @PersistenceContext
-    private EntityManager entityManager;
 
     private User testUser;
     private Category testCategory;
@@ -179,33 +174,4 @@ class SubscribeRepositoryTest extends RepositoryTest {
         Subscribe updatedSubscribe = subscribeRepository.findById(savedSubscribe.getId()).orElseThrow();
         assertThat(updatedSubscribe.getKeyword()).isEqualTo("아이패드");
     }
-
-
-//    @Test
-//    @DisplayName("구독 정보를 수정할 수 있다.")
-//    void updateSubscribeTest() {
-//        // Given
-//        Subscribe subscribe = Subscribe.builder()
-//                .user(testUser)
-//                .keyword("태블릿")
-//                .category(testCategory)
-//                .region(testLocation.getName())
-//                .build();
-//
-//        Subscribe savedSubscribe = subscribeRepository.save(subscribe);
-//        entityManager.flush();
-//        entityManager.clear();
-//
-//        // When
-//        Subscribe foundSubscribe = subscribeRepository.findById(savedSubscribe.getId()).orElseThrow();
-//        foundSubscribe.updateKeyword("스마트폰");
-//        subscribeRepository.save(foundSubscribe);
-//        entityManager.flush();
-//        entityManager.clear();
-//
-//        // Then
-//        Subscribe updatedSubscribe = subscribeRepository.findById(savedSubscribe.getId()).orElseThrow();
-//        assertThat(updatedSubscribe.getKeyword()).isEqualTo("스마트폰");
-//    }
-
 }

--- a/src/test/java/org/lostnomore/backend/subscribe/service/SubscribeServiceTest.java
+++ b/src/test/java/org/lostnomore/backend/subscribe/service/SubscribeServiceTest.java
@@ -5,29 +5,42 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.lostnomore.backend.common.ServiceTest;
+import org.lostnomore.backend.global.exception.BusinessException;
+import org.lostnomore.backend.global.exception.code.SubscribeErrorCode;
 import org.lostnomore.backend.item.domain.Category;
 import org.lostnomore.backend.item.domain.Location;
 import org.lostnomore.backend.item.domain.LostItem;
 import org.lostnomore.backend.item.elastic.LostItemDocument;
 import org.lostnomore.backend.item.elastic.LostItemSearchService;
+import org.lostnomore.backend.item.manager.CategoryRetriever;
+import org.lostnomore.backend.item.manager.LocationRetriever;
 import org.lostnomore.backend.item.manager.LostItemRetriever;
 import org.lostnomore.backend.subscribe.domain.Subscribe;
+import org.lostnomore.backend.subscribe.dto.request.SubscribeCreateDto;
 import org.lostnomore.backend.subscribe.dto.response.RecentItemsDto;
 import org.lostnomore.backend.subscribe.dto.response.SubscribeListDto;
+import org.lostnomore.backend.subscribe.dto.response.SubscribesDto;
+import org.lostnomore.backend.subscribe.manager.SubscribeCreator;
+import org.lostnomore.backend.subscribe.manager.SubscribeEditor;
+import org.lostnomore.backend.subscribe.manager.SubscribeRemover;
 import org.lostnomore.backend.subscribe.manager.SubscribeRetriever;
 import org.lostnomore.backend.user.domain.User;
+import org.lostnomore.backend.user.manager.UserRetriever;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.data.elasticsearch.core.SearchHit;
 import org.springframework.data.elasticsearch.core.SearchHits;
 
+import java.lang.reflect.Field;
 import java.time.LocalDate;
 import java.util.Collections;
 import java.util.List;
 import java.util.Set;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.Mockito.*;
 
@@ -35,7 +48,25 @@ import static org.mockito.Mockito.*;
 class SubscribeServiceTest extends ServiceTest {
 
     @Mock
+    private UserRetriever userRetriever;
+
+    @Mock
+    private CategoryRetriever categoryRetriever;
+
+    @Mock
+    private LocationRetriever locationRetriever;
+
+    @Mock
+    private SubscribeCreator subscribeCreator;
+
+    @Mock
     private SubscribeRetriever subscribeRetriever;
+
+    @Mock
+    private SubscribeEditor subscribeEditor;
+
+    @Mock
+    private SubscribeRemover subscribeRemover;
 
     @Mock
     private LostItemRetriever lostItemRetriever;
@@ -47,6 +78,7 @@ class SubscribeServiceTest extends ServiceTest {
     private SubscribeService subscribeService;
 
     private Long testUserId;
+    private Long anotherUserId;
     private User testUser;
     private Category category;
     private Location location;
@@ -57,20 +89,28 @@ class SubscribeServiceTest extends ServiceTest {
     private SearchHits<LostItemDocument> searchHits;
     private LostItem lostItem;
     private List<LostItem> lostItems;
+    private SubscribeCreateDto subscribeCreateDto;
     private final LocalDate dateEnd = LocalDate.now().minusDays(1);
     private final LocalDate dateStart = dateEnd.minusDays(7);
 
     @BeforeEach
-    void setUp() {
+    void setUp() throws NoSuchFieldException, IllegalAccessException {
         testUserId = 1L;
 
         testUser = User.builder().name("테스트 유저").build();
-        category = Category.builder().name("전자기기").build();
+
+        Field idField = User.class.getDeclaredField("id");
+        idField.setAccessible(true);
+        idField.set(testUser, testUserId);
+
+        category = Category.builder().name("지갑").build();
         location = Location.builder().name("서울").build();
+
+        subscribeCreateDto = new SubscribeCreateDto("고양이지갑", "지갑", "서울");
 
         subscribe = Subscribe.builder()
                 .user(testUser)
-                .keyword("지갑")
+                .keyword("고양이지갑")
                 .region("서울")
                 .category(category)
                 .build();
@@ -78,15 +118,15 @@ class SubscribeServiceTest extends ServiceTest {
 
         lostItemDocument = LostItemDocument.builder()
                 .id(100L)
-                .name("지갑")
+                .name("고양이지갑")
                 .region("서울")
                 .build();
 
         searchHit = mock(SearchHit.class);
-        when(searchHit.getContent()).thenReturn(lostItemDocument);
+        lenient().when(searchHit.getContent()).thenReturn(lostItemDocument);
 
         searchHits = mock(SearchHits.class);
-        when(searchHits.getSearchHits()).thenReturn(List.of(searchHit));
+        lenient().when(searchHits.getSearchHits()).thenReturn(List.of(searchHit));
 
         lostItem = LostItem.builder()
                 .name("지갑")
@@ -158,5 +198,157 @@ class SubscribeServiceTest extends ServiceTest {
         assertThat(result.lostItems()).isEmpty();
         assertThat(result.nextCursorDate()).isNull();
         assertThat(result.nextCursorId()).isNull();
+    }
+
+    @Test
+    @DisplayName("구독 생성이 성공한다.")
+    void createSubscribeTest() {
+        // Given
+        when(userRetriever.findById(anyLong())).thenReturn(testUser);
+        when(categoryRetriever.findByName(anyString())).thenReturn(category);
+        when(locationRetriever.findByRegion(anyString())).thenReturn(List.of(location));
+
+        // When
+        subscribeService.createSubscribe(testUserId, subscribeCreateDto);
+
+        // Then
+        verify(userRetriever, times(1)).findById(testUserId);
+        verify(categoryRetriever, times(1)).findByName(subscribeCreateDto.category());
+        verify(locationRetriever, times(1)).findByRegion(subscribeCreateDto.region());
+        verify(subscribeCreator, times(1)).save(argThat(subscribe ->
+                subscribe.getUser().equals(testUser) &&
+                        subscribe.getKeyword().equals(subscribeCreateDto.keyword()) &&
+                        subscribe.getRegion().equals(subscribeCreateDto.region()) &&
+                        subscribe.getCategory().equals(category)
+        ));
+    }
+
+    @Test
+    @DisplayName("중복 구독이 있으면 예외를 반환한다.")
+    void createSubscribe_DuplicateTest() {
+        // Given
+        when(userRetriever.findById(anyLong())).thenReturn(testUser);
+        when(categoryRetriever.findByName(anyString())).thenReturn(category);
+        when(locationRetriever.findByRegion(anyString())).thenReturn(List.of(location));
+        doThrow(new DataIntegrityViolationException("Duplicate entry"))
+                .when(subscribeCreator).save(any(Subscribe.class));
+
+        // When & Then
+        assertThatThrownBy(() -> subscribeService.createSubscribe(testUserId, subscribeCreateDto))
+                .isInstanceOf(BusinessException.class)
+                .satisfies(exception -> {
+                    BusinessException businessException = (BusinessException) exception;
+                    assertThat(businessException.getErrorCode()).isEqualTo(SubscribeErrorCode.SUBSCRIBE_DUPLICATE);
+                    assertThat(businessException.getErrorCode().getMessage()).isEqualTo("이미 등록된 구독 정보입니다.");
+                });
+
+        verify(subscribeCreator, times(1)).save(any(Subscribe.class));
+    }
+
+    @Test
+    @DisplayName("구독 목록을 조회하면 정상적으로 반환된다.")
+    void getSubscribeTest() {
+        // Given
+        when(subscribeRetriever.findByUserId(anyLong())).thenReturn(subscribes);
+
+        // When
+        SubscribesDto result = subscribeService.getSubscribes(testUserId);
+
+        // Then
+        assertThat(result.subscribes()).hasSize(1);
+        assertThat(result.subscribes().get(0).keyword()).isEqualTo("고양이지갑");
+        assertThat(result.subscribes().get(0).region()).isEqualTo("서울");
+
+        verify(subscribeRetriever, times(1)).findByUserId(testUserId);
+    }
+
+    @Test
+    @DisplayName("구독 삭제가 성공한다.")
+    void deleteSubscribeTest() {
+        // Given
+        when(subscribeRetriever.findById(anyLong())).thenReturn(subscribe);
+
+        // When
+        subscribeService.deleteSubscribe(testUserId, 100L);
+
+        // Then
+        verify(subscribeRetriever, times(1)).findById(100L);
+        verify(subscribeRemover, times(1)).deleteById(100L);
+    }
+
+    @Test
+    @DisplayName("다른 유저의 구독을 삭제하면 예외가 발생한다.")
+    void deleteSubscribe_ForbiddenTest() throws NoSuchFieldException, IllegalAccessException {
+        // Given
+        anotherUserId = 2L;
+        User anotherUser = User.builder().name("다른 유저").build();
+        Field idField = User.class.getDeclaredField("id");
+        idField.setAccessible(true);
+        idField.set(anotherUser, anotherUserId);
+        Subscribe anotherSubscribe = Subscribe.builder()
+                .user(anotherUser)
+                .keyword("노트북")
+                .region("부산")
+                .category(category)
+                .build();
+        when(subscribeRetriever.findById(anyLong())).thenReturn(anotherSubscribe);
+
+        // When & Then
+        assertThatThrownBy(() -> subscribeService.deleteSubscribe(testUserId, 100L))
+                .isInstanceOf(BusinessException.class)
+                .satisfies(exception -> {
+                    BusinessException businessException = (BusinessException) exception;
+                    assertThat(businessException.getErrorCode()).isEqualTo(SubscribeErrorCode.SUBSCRIBE_FORBIDDEN);
+                    assertThat(businessException.getErrorCode().getMessage()).isEqualTo("해당 구독에 대한 권한이 없습니다.");
+                });
+
+        verify(subscribeRemover, never()).deleteById(anyLong());
+    }
+
+    @Test
+    @DisplayName("구독 정보 업데이트가 성공한다.")
+    void updateSubscribeTest() {
+        // Given
+        SubscribeCreateDto updatedSubscribeDto = new SubscribeCreateDto("백팩", "가방", "부산");
+        when(subscribeRetriever.findById(anyLong())).thenReturn(subscribe);
+        when(categoryRetriever.findByName(anyString())).thenReturn(category);
+        when(locationRetriever.findByRegion(anyString())).thenReturn(List.of(location));
+
+        // When
+        subscribeService.updateSubscribe(testUserId, 100L, updatedSubscribeDto);
+
+        // Then
+        verify(subscribeEditor, times(1)).updateSubscribe(subscribe, "백팩", category, "부산");
+    }
+
+    @Test
+    @DisplayName("다른 유저의 구독을 수정하면 예외가 발생한다.")
+    void updateSubscribe_ForbiddenTest() throws NoSuchFieldException, IllegalAccessException {
+        // Given
+        anotherUserId = 2L;
+        User anotherUser = User.builder().name("다른 유저").build();
+        Field idField = User.class.getDeclaredField("id");
+        idField.setAccessible(true);
+        idField.set(anotherUser, anotherUserId);
+        Subscribe anotherSubscribe = Subscribe.builder()
+                .user(anotherUser)
+                .keyword("노트북")
+                .region("부산")
+                .category(category)
+                .build();
+        SubscribeCreateDto updatedSubscribeDto = new SubscribeCreateDto("가방", "부산", "전자기기");
+
+        when(subscribeRetriever.findById(anyLong())).thenReturn(anotherSubscribe);
+
+        // When & Then
+        assertThatThrownBy(() -> subscribeService.updateSubscribe(testUserId, 100L, updatedSubscribeDto))
+                .isInstanceOf(BusinessException.class)
+                .satisfies(exception -> {
+                    BusinessException businessException = (BusinessException) exception;
+                    assertThat(businessException.getErrorCode()).isEqualTo(SubscribeErrorCode.SUBSCRIBE_FORBIDDEN);
+                    assertThat(businessException.getErrorCode().getMessage()).isEqualTo("해당 구독에 대한 권한이 없습니다.");
+                });
+
+        verify(subscribeEditor, never()).updateSubscribe(any(), any(), any(), any());
     }
 }


### PR DESCRIPTION
## Related issue 🛠
[//]: # (해당하는 이슈 번호 달아주기)
- closed #34 

## Work Description ✏️
[//]: # (작업 내용 간단 소개)
- 키워드 구독 관련 API 구현했습니다.
- 서비스, 레포지토리 테스트 코드 작성했습니다.

## Uncompleted Tasks 😅
[//]: # (없다면 N/A)
- [ ] N/A

## To Reviewers 📢
[//]: # (reviewer가 알면 좋은 내용들)