### PR TITLE
[FEAT] 분실물 구독 리스트 필터링 추가 

### DIFF
--- a/src/main/java/org/lostnomore/backend/subscribe/controller/SubscribeController.java
+++ b/src/main/java/org/lostnomore/backend/subscribe/controller/SubscribeController.java
@@ -34,12 +34,15 @@ public class SubscribeController {
             @RequestParam @DateTimeFormat(pattern = "yyyy-MM-dd") LocalDate date_start,
             @RequestParam @DateTimeFormat(pattern = "yyyy-MM-dd") LocalDate date_end,
             @RequestParam(required = false) String keyword,
+            @RequestParam(required = false) String category,
+            @RequestParam(required = false) String region,
             @RequestParam(required = false) @DateTimeFormat(pattern = "yyyy-MM-dd") LocalDate cursorDate,
             @RequestParam(required = false) Long cursorId,
             @RequestParam(defaultValue = "8") int size
     ) {
         return ResponseEntity.ok().body(ResponseDto.success(subscribeService.getSubscribeList(
-                userId, date_start, date_end, keyword,
+                userId, date_start, date_end,
+                keyword, category, region,
                 cursorDate, cursorId, size
         )));
     }

--- a/src/main/java/org/lostnomore/backend/subscribe/service/SubscribeService.java
+++ b/src/main/java/org/lostnomore/backend/subscribe/service/SubscribeService.java
@@ -67,18 +67,18 @@ public class SubscribeService {
     public SubscribeListDto getSubscribeList(
             final Long userId,
             final LocalDate dateStart, final LocalDate dateEnd,
-            final String keyword,
+            final String keyword, final String category, final String region,
             final LocalDate cursorDate,
             final Long cursorId,
             final int size
     ) {
-        List<Subscribe> subscribes = subscribeRetriever.findByUserId(userId);
 
-        if (keyword != null) {
-            subscribes = subscribes.stream()
-                    .filter(subscribe -> keyword.equals(subscribe.getKeyword()))
-                    .toList();
-        }
+        List<Subscribe> subscribes = subscribeRetriever.findByUserId(userId)
+                .stream()
+                .filter(subscribe -> keyword == null || keyword.equals(subscribe.getKeyword()))
+                .filter(subscribe -> category == null || category.equals(subscribe.getCategory().getName()))
+                .filter(subscribe -> region == null || region.equals(subscribe.getRegion()))
+                .toList();
 
         Set<Long> lostItemIds = searchLostItemIds(subscribes, dateStart, dateEnd, null);
 

--- a/src/test/java/org/lostnomore/backend/subscribe/service/SubscribeServiceTest.java
+++ b/src/test/java/org/lostnomore/backend/subscribe/service/SubscribeServiceTest.java
@@ -169,7 +169,7 @@ class SubscribeServiceTest extends ServiceTest {
                 .thenReturn(lostItems);
 
         // When
-        SubscribeListDto result = subscribeService.getSubscribeList(testUserId, dateStart, dateEnd, null, null, null, 8);
+        SubscribeListDto result = subscribeService.getSubscribeList(testUserId, dateStart, dateEnd, null, null, null, null,null,8);
 
         // Then
         assertThat(result.lostItems()).hasSize(1);
@@ -192,7 +192,7 @@ class SubscribeServiceTest extends ServiceTest {
                 .thenReturn(Collections.emptyList());
 
         // When
-        SubscribeListDto result = subscribeService.getSubscribeList(testUserId, dateStart, dateEnd, null, null, null, 5);
+        SubscribeListDto result = subscribeService.getSubscribeList(testUserId, dateStart, dateEnd, null, null, null, null,null,5);
 
         // Then
         assertThat(result.lostItems()).isEmpty();


### PR DESCRIPTION
## Related issue 🛠
[//]: # (해당하는 이슈 번호 달아주기)
- closed #42

## Work Description ✏️
[//]: # (작업 내용 간단 소개)
- 분실물 구독 리스트에 필터링(카테고리, 지역) 추가했습니다.

## Uncompleted Tasks 😅
[//]: # (없다면 N/A)
- [ ] N/A

## To Reviewers 📢
[//]: # (reviewer가 알면 좋은 내용들)