### PR TITLE
[FIX] 최근 분실물 조회 응답값에 category 추가 

### DIFF
--- a/src/main/java/org/lostnomore/backend/subscribe/dto/response/RecentItemsDto.java
+++ b/src/main/java/org/lostnomore/backend/subscribe/dto/response/RecentItemsDto.java
@@ -21,6 +21,7 @@ public record RecentItemsDto(
             String name,
             LocalDate date,
             String location,
+            String category,
             String imageUrl
     ) {
         public static RecentItemDto from(LostItem item) {
@@ -29,6 +30,7 @@ public record RecentItemsDto(
                     item.getName(),
                     item.getDate(),
                     item.getLocation().getName(),
+                    item.getCategory().getName(),
                     item.getImage()
             );
         }


### PR DESCRIPTION
## Related issue 🛠
[//]: # (해당하는 이슈 번호 달아주기)
- closed #44

## Work Description ✏️
[//]: # (작업 내용 간단 소개)
- 최근 분실물 조회 응답값에 category가 빠져있어 추가했습니다.

## Uncompleted Tasks 😅
[//]: # (없다면 N/A)
- [ ] N/A

## To Reviewers 📢
[//]: # (reviewer가 알면 좋은 내용들)