### PR TITLE
[FEAT] 엘라스틱 서치 검색 성능 개선

### DIFF
--- a/.github/workflows/dev-ci.yml
+++ b/.github/workflows/dev-ci.yml
@@ -55,6 +55,76 @@ jobs:
           echo "Elasticsearch is up!"
         shell: bash
 
+      - name: Create Elasticsearch Index  # ✅ Elasticsearch 인덱스 생성
+        run: |
+          echo "Creating Elasticsearch index..."
+          curl -X PUT "http://localhost:9200/lost_item" \
+            -H "Content-Type: application/json" \
+            -d '
+            {
+              "settings": {
+                "analysis": {
+                  "tokenizer": {
+                    "edge_ngram_tokenizer": {
+                      "type": "edge_ngram",
+                      "min_gram": 2,
+                      "max_gram": 5,
+                      "token_chars": ["letter", "digit", "whitespace"]
+                    },
+                    "nori_tokenizer": {
+                      "type": "nori_tokenizer"
+                    }
+                  },
+                  "analyzer": {
+                    "nori_analyzer": {
+                      "type": "custom",
+                      "tokenizer": "nori_tokenizer",
+                      "filter": ["nori_readingform", "nori_part_of_speech"]
+                    },
+                    "ngram_analyzer": {
+                      "type": "custom",
+                      "tokenizer": "edge_ngram_tokenizer"
+                    }
+                  }
+                }
+              },
+              "mappings": {
+                "properties": {
+                  "name": {
+                    "type": "text",
+                    "fields": {
+                      "standard": {
+                        "type": "text",
+                        "analyzer": "standard"
+                      },
+                      "nori": {
+                        "type": "text",
+                        "analyzer": "nori_analyzer"
+                      },
+                      "ngram": {
+                        "type": "text",
+                        "analyzer": "ngram_analyzer"
+                      }
+                    }
+                  },
+                  "date": {
+                    "type": "date"
+                  },
+                  "categoryId": {
+                    "type": "long"
+                  },
+                  "region": {
+                    "type": "text",
+                    "analyzer": "nori_analyzer"
+                  },
+                  "location": {
+                    "type": "geo_point"
+                  }
+                }
+              }
+            }'
+        shell: bash
+
       - name: Check Elasticsearch Health
         run: curl -s http://localhost:9200/_cluster/health?pretty
         shell: bash

--- a/.github/workflows/dev-ci.yml
+++ b/.github/workflows/dev-ci.yml
@@ -152,12 +152,6 @@ jobs:
           ./gradlew build
         shell: bash
 
-      - name: Run Tests with Debugging**
-        run: |
-          echo "Running tests with debug logs..."
-          ./gradlew test --info --stacktrace
-        shell: bash
-
       - name: Publish Test Results
         uses: EnricoMi/publish-unit-test-result-action@v2
         if: always()

--- a/.github/workflows/dev-ci.yml
+++ b/.github/workflows/dev-ci.yml
@@ -152,6 +152,12 @@ jobs:
           ./gradlew build
         shell: bash
 
+      - name: Run Tests with Debugging**
+        run: |
+          echo "Running tests with debug logs..."
+          ./gradlew test --info --stacktrace
+        shell: bash
+
       - name: Publish Test Results
         uses: EnricoMi/publish-unit-test-result-action@v2
         if: always()

--- a/.github/workflows/dev-ci.yml
+++ b/.github/workflows/dev-ci.yml
@@ -55,7 +55,24 @@ jobs:
           echo "Elasticsearch is up!"
         shell: bash
 
-      - name: Create Elasticsearch Index  # ✅ Elasticsearch 인덱스 생성
+      - name: Install Elasticsearch Nori Plugin
+        run: |
+          echo "Installing Nori plugin..."
+          until curl -s http://localhost:9200 > /dev/null; do sleep 2; done
+          docker exec $(docker ps -q --filter ancestor=docker.elastic.co/elasticsearch/elasticsearch:8.17.1) \
+          bin/elasticsearch-plugin install analysis-nori
+          echo "Restarting Elasticsearch..."
+          docker restart $(docker ps -q --filter ancestor=docker.elastic.co/elasticsearch/elasticsearch:8.17.1)
+        shell: bash
+
+      - name: Wait for Elasticsearch after Restart
+        run: |
+          echo "Waiting for Elasticsearch to be available after restart..."
+          timeout 60s bash -c 'until curl -s http://localhost:9200 > /dev/null; do sleep 2; echo "Still waiting..."; done'
+          echo "Elasticsearch is up after restart!"
+        shell: bash
+
+      - name: Create Elasticsearch Index
         run: |
           echo "Creating Elasticsearch index..."
           curl -X PUT "http://localhost:9200/lost_item" \

--- a/src/main/java/org/lostnomore/backend/item/elastic/LostItemDocument.java
+++ b/src/main/java/org/lostnomore/backend/item/elastic/LostItemDocument.java
@@ -3,10 +3,7 @@ package org.lostnomore.backend.item.elastic;
 import lombok.Builder;
 import lombok.Data;
 import org.springframework.data.annotation.Id;
-import org.springframework.data.elasticsearch.annotations.Document;
-import org.springframework.data.elasticsearch.annotations.Field;
-import org.springframework.data.elasticsearch.annotations.FieldType;
-import org.springframework.data.elasticsearch.annotations.GeoPointField;
+import org.springframework.data.elasticsearch.annotations.*;
 import org.springframework.data.elasticsearch.core.geo.GeoPoint;
 
 import java.time.LocalDate;
@@ -18,7 +15,12 @@ public class LostItemDocument {
     @Id
     private Long id;
 
-    @Field(type = FieldType.Text, analyzer = "standard")
+    @MultiField(
+            mainField = @Field(type = FieldType.Text, analyzer = "nori_analyzer", searchAnalyzer = "nori_analyzer"),
+            otherFields = {
+                    @InnerField(suffix = "ngram", type = FieldType.Text, analyzer = "ngram_analyzer")
+            }
+    )
     private String name;
 
     @Field(type = FieldType.Date)
@@ -27,7 +29,7 @@ public class LostItemDocument {
     @Field(type = FieldType.Long)
     private Long categoryId;
 
-    @Field(type = FieldType.Text, analyzer = "standard")
+    @Field(type = FieldType.Text, analyzer = "nori_analyzer", searchAnalyzer = "nori_analyzer")
     private String region;
 
     @GeoPointField

--- a/src/main/java/org/lostnomore/backend/item/elastic/LostItemDocument.java
+++ b/src/main/java/org/lostnomore/backend/item/elastic/LostItemDocument.java
@@ -16,8 +16,9 @@ public class LostItemDocument {
     private Long id;
 
     @MultiField(
-            mainField = @Field(type = FieldType.Text, analyzer = "nori_analyzer", searchAnalyzer = "nori_analyzer"),
+            mainField = @Field(type = FieldType.Text, analyzer = "standard"),
             otherFields = {
+                    @InnerField(suffix = "nori", type = FieldType.Text, analyzer = "nori_analyzer"),
                     @InnerField(suffix = "ngram", type = FieldType.Text, analyzer = "ngram_analyzer")
             }
     )

--- a/src/main/java/org/lostnomore/backend/item/elastic/LostItemSearchService.java
+++ b/src/main/java/org/lostnomore/backend/item/elastic/LostItemSearchService.java
@@ -24,6 +24,7 @@ import java.util.List;
 public class LostItemSearchService {
 
     private final ElasticsearchOperations elasticsearchOperations;
+    private final NoriAnalyzerService noriAnalyzerService;
 
     @Transactional(readOnly = true)
     public SearchHits<LostItemDocument> searchLostItems(
@@ -56,25 +57,46 @@ public class LostItemSearchService {
         boolean hasKeyword = (keyword != null && !keyword.isBlank());
 
         if (hasKeyword) {
-            // Nori 기반
-            MatchQuery matchQuery = MatchQuery.of(m -> m
-                    .field("name.nori")
-                    .query(keyword)
-            );
-            shouldQueries.add(matchQuery._toQuery());
+
+            List<String> tokens = noriAnalyzerService.analyzeKeyword(keyword);
+
+            if (tokens.size() > 1) {
+                // 다중 토큰일 경우 각 토큰을 전부 must로 추가
+                for (String token : tokens) {
+                    MatchQuery multiTokenMatch = MatchQuery.of(m -> m
+                            .field("name.nori")
+                            .query(token)
+                    );
+                    mustQueries.add(multiTokenMatch._toQuery());
+                }
+            } else {
+                // 단일 토큰일 경우 기존처럼 should에 추가
+                MatchQuery singleTokenMatch = MatchQuery.of(m -> m
+                        .field("name.nori")
+                        .query(keyword)
+                );
+                shouldQueries.add(singleTokenMatch._toQuery());
+            }
 
             // Edge NGram 기반
-            MatchQuery ngramMatchQuery = MatchQuery.of(m -> m
+            MatchQuery ngramQuery = MatchQuery.of(m -> m
                     .field("name.ngram")
                     .query(keyword)
             );
-            shouldQueries.add(ngramMatchQuery._toQuery());
+            shouldQueries.add(ngramQuery._toQuery());
 
-            // 유사 검색
+            // 접두사 기반 검색
+            MatchPhrasePrefixQuery phrasePrefix = MatchPhrasePrefixQuery.of(m -> m
+                    .field("name.nori")
+                    .query(keyword)
+            );
+            shouldQueries.add(phrasePrefix._toQuery());
+
+            // Fuzzy 철자 오류 보정
             FuzzyQuery fuzzyQuery = FuzzyQuery.of(f -> f
                     .field("name")
                     .value(keyword)
-                    .fuzziness("AUTO") // 자동으로 철자 오류 보정
+                    .fuzziness("AUTO")
             );
             shouldQueries.add(fuzzyQuery._toQuery());
         }

--- a/src/main/java/org/lostnomore/backend/item/elastic/LostItemSearchService.java
+++ b/src/main/java/org/lostnomore/backend/item/elastic/LostItemSearchService.java
@@ -56,20 +56,27 @@ public class LostItemSearchService {
         boolean hasKeyword = (keyword != null && !keyword.isBlank());
 
         if (hasKeyword) {
+            // Nori 기반
+            MatchQuery matchQuery = MatchQuery.of(m -> m
+                    .field("name.nori")
+                    .query(keyword)
+            );
+            shouldQueries.add(matchQuery._toQuery());
+
+            // Edge NGram 기반
+            MatchQuery ngramMatchQuery = MatchQuery.of(m -> m
+                    .field("name.ngram")
+                    .query(keyword)
+            );
+            shouldQueries.add(ngramMatchQuery._toQuery());
+
             // 유사 검색
             FuzzyQuery fuzzyQuery = FuzzyQuery.of(f -> f
                     .field("name")
                     .value(keyword)
-                    .fuzziness("AUTO")
+                    .fuzziness("AUTO") // 자동으로 철자 오류 보정
             );
             shouldQueries.add(fuzzyQuery._toQuery());
-
-            // 부분 검색
-            PrefixQuery prefixQuery = PrefixQuery.of(p -> p
-                    .field("name")
-                    .value(keyword)
-            );
-            shouldQueries.add(prefixQuery._toQuery());
         }
 
         // 카테고리

--- a/src/main/java/org/lostnomore/backend/item/elastic/NoriAnalyzerService.java
+++ b/src/main/java/org/lostnomore/backend/item/elastic/NoriAnalyzerService.java
@@ -1,0 +1,49 @@
+package org.lostnomore.backend.item.elastic;
+
+import org.springframework.stereotype.Service;
+import org.springframework.web.client.RestTemplate;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.util.ArrayList;
+import java.util.List;
+
+@Service
+public class NoriAnalyzerService {
+
+    private final RestTemplate restTemplate;
+    private final ObjectMapper objectMapper;
+    private static final String ELASTICSEARCH_URL = "http://localhost:9200/lost_item/_analyze";
+
+    public NoriAnalyzerService(RestTemplate restTemplate, ObjectMapper objectMapper) {
+        this.restTemplate = restTemplate;
+        this.objectMapper = objectMapper;
+    }
+
+    public List<String> analyzeKeyword(String keyword) {
+        try {
+            String requestJson = "{ \"analyzer\": \"nori_analyzer\", \"text\": \"" + keyword + "\" }";
+
+            HttpHeaders headers = new HttpHeaders();
+            headers.setContentType(MediaType.APPLICATION_JSON);
+            HttpEntity<String> entity = new HttpEntity<>(requestJson, headers);
+
+            ResponseEntity<String> response = restTemplate.postForEntity(ELASTICSEARCH_URL, entity, String.class);
+
+            JsonNode rootNode = objectMapper.readTree(response.getBody());
+            List<String> tokens = new ArrayList<>();
+            for (JsonNode tokenNode : rootNode.path("tokens")) {
+                tokens.add(tokenNode.path("token").asText());
+            }
+
+            return tokens;
+
+        } catch (Exception e) {
+            e.printStackTrace();
+            return List.of(keyword);
+        }
+    }
+}

--- a/src/test/java/org/lostnomore/backend/BackendApplicationTests.java
+++ b/src/test/java/org/lostnomore/backend/BackendApplicationTests.java
@@ -1,34 +1,10 @@
 package org.lostnomore.backend;
 
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.lostnomore.backend.item.elastic.LostItemSearchService;
-import org.lostnomore.backend.item.elastic.NoriAnalyzerService;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.data.elasticsearch.core.ElasticsearchOperations;
-import org.springframework.test.context.bean.override.mockito.MockitoBean;
-
-import java.util.List;
-
-import static org.mockito.ArgumentMatchers.anyString;
-import static org.mockito.Mockito.when;
 
 @SpringBootTest
 class BackendApplicationTests {
-
-	@MockitoBean
-	private LostItemSearchService lostItemSearchService;
-
-	@MockitoBean
-	private ElasticsearchOperations elasticsearchOperations;
-
-	@MockitoBean
-	private NoriAnalyzerService noriAnalyzerService;
-
-	@BeforeEach
-	void setUp() {
-		when(noriAnalyzerService.analyzeKeyword(anyString())).thenReturn(List.of("mocked", "tokens"));
-	}
 
 	@Test
 	void contextLoads() {

--- a/src/test/java/org/lostnomore/backend/BackendApplicationTests.java
+++ b/src/test/java/org/lostnomore/backend/BackendApplicationTests.java
@@ -1,15 +1,26 @@
 package org.lostnomore.backend;
 
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.lostnomore.backend.item.elastic.NoriAnalyzerService;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
+
+import java.util.List;
+
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.when;
 
 @SpringBootTest
 class BackendApplicationTests {
 
 	@MockitoBean
 	private NoriAnalyzerService noriAnalyzerService;
+
+	@BeforeEach
+	void setUp() {
+		when(noriAnalyzerService.analyzeKeyword(anyString())).thenReturn(List.of("mocked", "tokens"));
+	}
 
 	@Test
 	void contextLoads() {

--- a/src/test/java/org/lostnomore/backend/BackendApplicationTests.java
+++ b/src/test/java/org/lostnomore/backend/BackendApplicationTests.java
@@ -1,10 +1,15 @@
 package org.lostnomore.backend;
 
 import org.junit.jupiter.api.Test;
+import org.lostnomore.backend.item.elastic.NoriAnalyzerService;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 
 @SpringBootTest
 class BackendApplicationTests {
+
+	@MockitoBean
+	private NoriAnalyzerService noriAnalyzerService;
 
 	@Test
 	void contextLoads() {

--- a/src/test/java/org/lostnomore/backend/BackendApplicationTests.java
+++ b/src/test/java/org/lostnomore/backend/BackendApplicationTests.java
@@ -2,8 +2,10 @@ package org.lostnomore.backend;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.lostnomore.backend.item.elastic.LostItemSearchService;
 import org.lostnomore.backend.item.elastic.NoriAnalyzerService;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.data.elasticsearch.core.ElasticsearchOperations;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 
 import java.util.List;
@@ -13,6 +15,12 @@ import static org.mockito.Mockito.when;
 
 @SpringBootTest
 class BackendApplicationTests {
+
+	@MockitoBean
+	private LostItemSearchService lostItemSearchService;
+
+	@MockitoBean
+	private ElasticsearchOperations elasticsearchOperations;
 
 	@MockitoBean
 	private NoriAnalyzerService noriAnalyzerService;


### PR DESCRIPTION
## Related issue 🛠
[//]: # (해당하는 이슈 번호 달아주기)
- closed #46

## Work Description ✏️
[//]: # (작업 내용 간단 소개)
- 기존에는 Elasticsearch 검색에서 예를 들어 **"강아지잠옷"** 을 검색할 때, "강아지"로는 검색되지만 "잠옷"으로는 검색되지 않는 문제가 확인되었습니다.
- 이를 해결하기 위해
   - ✅ Nori Analyzer를 적용하여 형태소 분석을 수행, "잠옷"으로도 검색 가능하도록 개선
   - ✅ 기존 Prefix 검색을 Edge NGram으로 변경하여 성능 최적화
하였습니다.

<img width="716" alt="image" src="https://github.com/user-attachments/assets/6f0cb7ed-207f-42fe-9c88-03494d6f761b" />


- 이후, **"강아지잠옷"** 이라고 검색했을 때, 강아지가 들어간 분실물과 잠옷이 들어간 분실물이 모두 검색되는 문제를 발견하고, 
강아지잠옷이라고 검색하면 강아지잠옷만 검색되도록 개선했습니다.

## Uncompleted Tasks 😅
[//]: # (없다면 N/A)
- [ ] N/A

## To Reviewers 📢
[//]: # (reviewer가 알면 좋은 내용들)