### PR TITLE
[FIX] 키워드 알림 구독 시 키워드로만 구독이 가능하도록 수정

### DIFF
--- a/src/main/java/org/lostnomore/backend/subscribe/controller/SubscribeController.java
+++ b/src/main/java/org/lostnomore/backend/subscribe/controller/SubscribeController.java
@@ -4,6 +4,7 @@ import lombok.RequiredArgsConstructor;
 import org.lostnomore.backend.global.LoginUser;
 import org.lostnomore.backend.global.dto.ResponseDto;
 import org.lostnomore.backend.subscribe.dto.request.SubscribeCreateDto;
+import org.lostnomore.backend.subscribe.dto.request.SubscribeUpdateDto;
 import org.lostnomore.backend.subscribe.dto.response.RecentItemsDto;
 import org.lostnomore.backend.subscribe.dto.response.SubscribeListDto;
 import org.lostnomore.backend.subscribe.dto.response.SubscribesDto;
@@ -76,9 +77,9 @@ public class SubscribeController {
     public ResponseEntity<ResponseDto<Void>> updateSubscribe (
             @LoginUser final Long userId,
             @PathVariable final Long subscribeId,
-            @RequestBody final SubscribeCreateDto subscribeCreateDto
+            @RequestBody final SubscribeUpdateDto subscribeUpdateDto
     ) {
-        subscribeService.updateSubscribe(userId, subscribeId, subscribeCreateDto);
+        subscribeService.updateSubscribe(userId, subscribeId, subscribeUpdateDto);
         return ResponseEntity.ok().body(ResponseDto.success());
     }
 }

--- a/src/main/java/org/lostnomore/backend/subscribe/domain/Subscribe.java
+++ b/src/main/java/org/lostnomore/backend/subscribe/domain/Subscribe.java
@@ -28,13 +28,13 @@ public class Subscribe extends BaseEntity {
     private User user;
 
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "category_id", nullable = false)
+    @JoinColumn(name = "category_id")
     private Category category;
 
     @Column(name = "keyword", nullable = false)
     private String keyword;
 
-    @Column(name = "region", nullable = false)
+    @Column(name = "region")
     private String region;
 
     @Builder

--- a/src/main/java/org/lostnomore/backend/subscribe/dto/request/SubscribeCreateDto.java
+++ b/src/main/java/org/lostnomore/backend/subscribe/dto/request/SubscribeCreateDto.java
@@ -1,8 +1,6 @@
 package org.lostnomore.backend.subscribe.dto.request;
 
 public record SubscribeCreateDto(
-        String keyword,
-        String category,
-        String region
+        String keyword
 ) {
 }

--- a/src/main/java/org/lostnomore/backend/subscribe/dto/request/SubscribeUpdateDto.java
+++ b/src/main/java/org/lostnomore/backend/subscribe/dto/request/SubscribeUpdateDto.java
@@ -1,0 +1,8 @@
+package org.lostnomore.backend.subscribe.dto.request;
+
+public record SubscribeUpdateDto(
+        String keyword,
+        String category,
+        String region
+) {
+}

--- a/src/main/java/org/lostnomore/backend/subscribe/manager/SubscribeEditor.java
+++ b/src/main/java/org/lostnomore/backend/subscribe/manager/SubscribeEditor.java
@@ -3,7 +3,6 @@ package org.lostnomore.backend.subscribe.manager;
 import lombok.RequiredArgsConstructor;
 import org.lostnomore.backend.item.domain.Category;
 import org.lostnomore.backend.subscribe.domain.Subscribe;
-import org.lostnomore.backend.subscribe.dto.request.SubscribeCreateDto;
 import org.lostnomore.backend.subscribe.repository.SubscribeRepository;
 import org.springframework.stereotype.Component;
 

--- a/src/main/java/org/lostnomore/backend/subscribe/service/SubscribeService.java
+++ b/src/main/java/org/lostnomore/backend/subscribe/service/SubscribeService.java
@@ -14,6 +14,7 @@ import org.lostnomore.backend.item.manager.LocationRetriever;
 import org.lostnomore.backend.item.manager.LostItemRetriever;
 import org.lostnomore.backend.subscribe.domain.Subscribe;
 import org.lostnomore.backend.subscribe.dto.request.SubscribeCreateDto;
+import org.lostnomore.backend.subscribe.dto.request.SubscribeUpdateDto;
 import org.lostnomore.backend.subscribe.dto.response.RecentItemsDto;
 import org.lostnomore.backend.subscribe.dto.response.SubscribeListDto;
 import org.lostnomore.backend.subscribe.dto.response.SubscribesDto;
@@ -128,14 +129,10 @@ public class SubscribeService {
             final SubscribeCreateDto subscribeCreateDto
     ) {
        User user = userRetriever.findById(userId);
-       validateRegionExists(subscribeCreateDto.region());
-       Category category = categoryRetriever.findByName(subscribeCreateDto.category());
 
        Subscribe subscribe = Subscribe.builder()
                .user(user)
                .keyword(subscribeCreateDto.keyword())
-               .category(category)
-               .region(subscribeCreateDto.region())
                .build();
 
         try {
@@ -165,7 +162,7 @@ public class SubscribeService {
     public void updateSubscribe(
             final Long userId,
             final Long subscribeId,
-            final SubscribeCreateDto subscribeDto
+            final SubscribeUpdateDto subscribeDto
     ) {
         Subscribe subscribe = subscribeRetriever.findById(subscribeId);
         validateSubscribeOwner(userId, subscribe);

--- a/src/test/java/org/lostnomore/backend/subscribe/service/SubscribeServiceTest.java
+++ b/src/test/java/org/lostnomore/backend/subscribe/service/SubscribeServiceTest.java
@@ -17,6 +17,7 @@ import org.lostnomore.backend.item.manager.LocationRetriever;
 import org.lostnomore.backend.item.manager.LostItemRetriever;
 import org.lostnomore.backend.subscribe.domain.Subscribe;
 import org.lostnomore.backend.subscribe.dto.request.SubscribeCreateDto;
+import org.lostnomore.backend.subscribe.dto.request.SubscribeUpdateDto;
 import org.lostnomore.backend.subscribe.dto.response.RecentItemsDto;
 import org.lostnomore.backend.subscribe.dto.response.SubscribeListDto;
 import org.lostnomore.backend.subscribe.dto.response.SubscribesDto;
@@ -37,7 +38,6 @@ import java.lang.reflect.Field;
 import java.time.LocalDate;
 import java.util.Collections;
 import java.util.List;
-import java.util.Set;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -90,6 +90,7 @@ class SubscribeServiceTest extends ServiceTest {
     private LostItem lostItem;
     private List<LostItem> lostItems;
     private SubscribeCreateDto subscribeCreateDto;
+    private SubscribeUpdateDto subscribeUpdateDto;
     private final LocalDate dateEnd = LocalDate.now().minusDays(1);
     private final LocalDate dateStart = dateEnd.minusDays(7);
 
@@ -106,7 +107,8 @@ class SubscribeServiceTest extends ServiceTest {
         category = Category.builder().name("지갑").build();
         location = Location.builder().name("서울").build();
 
-        subscribeCreateDto = new SubscribeCreateDto("고양이지갑", "지갑", "서울");
+        subscribeCreateDto = new SubscribeCreateDto("고양이지갑");
+        subscribeUpdateDto = new SubscribeUpdateDto("고양이지갑", "지갑", "서울");
 
         subscribe = Subscribe.builder()
                 .user(testUser)
@@ -205,21 +207,15 @@ class SubscribeServiceTest extends ServiceTest {
     void createSubscribeTest() {
         // Given
         when(userRetriever.findById(anyLong())).thenReturn(testUser);
-        when(categoryRetriever.findByName(anyString())).thenReturn(category);
-        when(locationRetriever.findByRegion(anyString())).thenReturn(List.of(location));
 
         // When
         subscribeService.createSubscribe(testUserId, subscribeCreateDto);
 
         // Then
         verify(userRetriever, times(1)).findById(testUserId);
-        verify(categoryRetriever, times(1)).findByName(subscribeCreateDto.category());
-        verify(locationRetriever, times(1)).findByRegion(subscribeCreateDto.region());
         verify(subscribeCreator, times(1)).save(argThat(subscribe ->
                 subscribe.getUser().equals(testUser) &&
-                        subscribe.getKeyword().equals(subscribeCreateDto.keyword()) &&
-                        subscribe.getRegion().equals(subscribeCreateDto.region()) &&
-                        subscribe.getCategory().equals(category)
+                        subscribe.getKeyword().equals(subscribeCreateDto.keyword())
         ));
     }
 
@@ -228,8 +224,6 @@ class SubscribeServiceTest extends ServiceTest {
     void createSubscribe_DuplicateTest() {
         // Given
         when(userRetriever.findById(anyLong())).thenReturn(testUser);
-        when(categoryRetriever.findByName(anyString())).thenReturn(category);
-        when(locationRetriever.findByRegion(anyString())).thenReturn(List.of(location));
         doThrow(new DataIntegrityViolationException("Duplicate entry"))
                 .when(subscribeCreator).save(any(Subscribe.class));
 
@@ -309,7 +303,7 @@ class SubscribeServiceTest extends ServiceTest {
     @DisplayName("구독 정보 업데이트가 성공한다.")
     void updateSubscribeTest() {
         // Given
-        SubscribeCreateDto updatedSubscribeDto = new SubscribeCreateDto("백팩", "가방", "부산");
+        SubscribeUpdateDto updatedSubscribeDto = new SubscribeUpdateDto("백팩", "가방", "부산");
         when(subscribeRetriever.findById(anyLong())).thenReturn(subscribe);
         when(categoryRetriever.findByName(anyString())).thenReturn(category);
         when(locationRetriever.findByRegion(anyString())).thenReturn(List.of(location));
@@ -336,7 +330,7 @@ class SubscribeServiceTest extends ServiceTest {
                 .region("부산")
                 .category(category)
                 .build();
-        SubscribeCreateDto updatedSubscribeDto = new SubscribeCreateDto("가방", "부산", "전자기기");
+        SubscribeUpdateDto updatedSubscribeDto = new SubscribeUpdateDto("가방", "부산", "전자기기");
 
         when(subscribeRetriever.findById(anyLong())).thenReturn(anotherSubscribe);
 


### PR DESCRIPTION
## Related issue 🛠
[//]: # (해당하는 이슈 번호 달아주기)
- closed #49

## Work Description ✏️
[//]: # (작업 내용 간단 소개)
- 키워드 알림 구독 생성 시에 키워드로만 구독이 가능하도록 하고, 이후 수정을 통해 카테고리와 지역을 설정할 수 있도록 했습니다.
- 따라서, 구독에서 카테고리와 지역의 nullable = false를 삭제하였고,
- 구독 생성 dto와 구독 수정 dto를 분리하였습니다.

## Uncompleted Tasks 😅
[//]: # (없다면 N/A)
- [ ] N/A

## To Reviewers 📢
[//]: # (reviewer가 알면 좋은 내용들)