### PR TITLE
[FIX] 페치조인을 할 때 카테고리가 null일 경우 제대로 조회가 되지 않는 오류 해결 

### DIFF
--- a/src/main/java/org/lostnomore/backend/subscribe/dto/response/SubscribesDto.java
+++ b/src/main/java/org/lostnomore/backend/subscribe/dto/response/SubscribesDto.java
@@ -27,7 +27,7 @@ public record SubscribesDto(
             return new SubscribeDto(
                     subscribe.getId(),
                     subscribe.getKeyword(),
-                    subscribe.getCategory().getName(),
+                    subscribe.getCategory() != null ? subscribe.getCategory().getName() : null,
                     subscribe.getRegion()
             );
         }

--- a/src/main/java/org/lostnomore/backend/subscribe/repository/SubscribeRepository.java
+++ b/src/main/java/org/lostnomore/backend/subscribe/repository/SubscribeRepository.java
@@ -13,7 +13,7 @@ public interface SubscribeRepository extends JpaRepository<Subscribe, Long> {
 
     @Query("""
        SELECT s FROM Subscribe s
-       JOIN FETCH s.category
+       LEFT JOIN FETCH s.category
        WHERE s.user.id = :userId
        """)
     List<Subscribe> findByUserId(Long userId);

--- a/src/main/java/org/lostnomore/backend/subscribe/service/SubscribeService.java
+++ b/src/main/java/org/lostnomore/backend/subscribe/service/SubscribeService.java
@@ -107,7 +107,7 @@ public class SubscribeService {
             SearchHits<LostItemDocument> searchHits = lostItemSearchService.searchLostItemsForSubscription(
                     dateStart, dateEnd,
                     subscribe.getKeyword(),
-                    subscribe.getCategory().getId(),
+                    subscribe.getCategory() != null ? subscribe.getCategory().getId() : null,
                     subscribe.getRegion(),
                     size
             );


### PR DESCRIPTION
## Related issue 🛠
[//]: # (해당하는 이슈 번호 달아주기)
- closed #51

## Work Description ✏️
[//]: # (작업 내용 간단 소개)
- 페치조인을 할 때 카테고리가 null일 경우 제대로 조회가 되지 않아 NullPointerException 오류가 발생
- 따라서 LEFT JOIN으로 수정
- null인 경우와 아닌 경우 나누어 처리

## Uncompleted Tasks 😅
[//]: # (없다면 N/A)
- [ ] N/A

## To Reviewers 📢
[//]: # (reviewer가 알면 좋은 내용들)