### PR TITLE
[FIX] 분실물 리스트 검색 분실물 id를 쿼리 파라미터로 받도록 수정

### DIFF
--- a/src/main/java/org/lostnomore/backend/item/controller/LostItemController.java
+++ b/src/main/java/org/lostnomore/backend/item/controller/LostItemController.java
@@ -16,6 +16,7 @@ import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.bind.annotation.*;
 
 import java.time.LocalDate;
+import java.util.List;
 
 @RestController
 @RequiredArgsConstructor
@@ -60,9 +61,9 @@ public class LostItemController {
 
     @GetMapping("/items/search/list")
     public ResponseEntity<ResponseDto<LostItemsListDto>> searchLostItemsList(
-            @RequestBody final LostItemIdsDto lostItemIdsDto
+            @RequestParam final List<Long> lostItemIds
     ) {
-        return ResponseEntity.ok().body(ResponseDto.success(lostItemService.searchLostItemsList(lostItemIdsDto.lostItemIds())));
+        return ResponseEntity.ok().body(ResponseDto.success(lostItemService.searchLostItemsList(lostItemIds)));
     }
 
     @GetMapping("/items/search/{lostItemId}")


### PR DESCRIPTION
## Related issue 🛠
[//]: # (해당하는 이슈 번호 달아주기)
- closed #54

## Work Description ✏️
[//]: # (작업 내용 간단 소개)
- GET 요청에서는 일반적으로 Request Body를 사용하지 않으므로, requestBody로 받던 lostIemIds를 쿼리 파라미터로 받도록 수정했습니다.

## Uncompleted Tasks 😅
[//]: # (없다면 N/A)
- [ ] N/A

## To Reviewers 📢
[//]: # (reviewer가 알면 좋은 내용들)