### PR TITLE
[FIX] ELASTICSEARCH_URL을 도커 컨테이너명으로 변경

### DIFF
--- a/src/main/java/org/lostnomore/backend/item/elastic/NoriAnalyzerService.java
+++ b/src/main/java/org/lostnomore/backend/item/elastic/NoriAnalyzerService.java
@@ -16,7 +16,7 @@ public class NoriAnalyzerService {
 
     private final RestTemplate restTemplate;
     private final ObjectMapper objectMapper;
-    private static final String ELASTICSEARCH_URL = "http://localhost:9200/lost_item/_analyze";
+    private static final String ELASTICSEARCH_URL = "http://lost-elasticsearch:9200/lost_item/_analyze";
 
     public NoriAnalyzerService(RestTemplate restTemplate, ObjectMapper objectMapper) {
         this.restTemplate = restTemplate;


### PR DESCRIPTION
## Related issue 🛠
[//]: # (해당하는 이슈 번호 달아주기)
- closed #<issue_number>

## Work Description ✏️
- ELASTICSEARCH_URL을 도커 컨테이너명으로 변경

## Uncompleted Tasks 😅
- [ ] N/A

## To Reviewers 📢
[//]: # (reviewer가 알면 좋은 내용들)